### PR TITLE
add serviceaccount management actions

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -58,6 +58,51 @@ upgrade:
           with load balancers conflicting with other clusters in the same
           project but will cause new load balancers to be created which will
           require manual intervention to resolve.
+sa-create:
+  description: Create a new ServiceAccount
+  params:
+    name:
+      type: string
+      description: Name of the serviceaccount to create
+      minLength: 2
+    namespace:
+      type: string
+      description: |
+        Namespace for the serviceaccount. If unspecified, the "default"
+        namespace will be used.
+    role:
+      type: string
+      description: |
+        Role to bind to the serviceaccount. If specified, the role must already
+        exist in the cluster. If unspecified, a new "$name-role" and
+        "$name-rolebinding" will be created.
+  required:
+    - name
+sa-delete:
+  description: |
+    Delete a ServiceAccount and related RoleBinding. Namespaces and Roles are
+    not deleted with this action.
+  params:
+    name:
+      type: string
+      description: Name of the serviceaccount to delete
+      minLength: 2
+    namespace:
+      type: string
+      description: |
+        Namespace of the serviceaccount to delete. If unspecified, the "default"
+        namespace will be used. This is only used to identify the serviceaccount;
+        namespaces are not deleted by this action.
+  required:
+    - name
+sa-list:
+  description: List existing ServiceAccounts
+  params:
+    namespace:
+      type: string
+      description: |
+        Namespace for the serviceaccounts to list. If unspecified, the "default"
+        namespace will be used.
 get-kubeconfig:
   description: Retrieve Kubernetes cluster config, including credentials
 apply-manifest:

--- a/actions/sa-create
+++ b/actions/sa-create
@@ -1,0 +1,102 @@
+#!/usr/local/sbin/charm-env python3
+import os
+import sys
+from charmhelpers.core import hookenv
+from charmhelpers.core.hookenv import (
+    action_get,
+    action_set,
+    action_fail,
+    action_name
+)
+from charmhelpers.core.templating import render
+from charms import layer
+from yaml import safe_load as load
+
+# Import charm layers and start reactive
+layer.import_layer_libs()
+hookenv._run_atstart()
+
+os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
+
+
+def protect_resources(*args):
+    '''Do not allow the action to operate on names used by Charmed Kubernetes.'''
+    for res in args:
+        if res in ['default', 'auth-webhook', 'auth-webhook-sa']:
+            action_fail('Not allowed to {} "{}".'.format(action, res))
+            sys.exit(0)
+
+
+def sa_list():
+    ns = action_get('namespace') or 'default'
+    y = load(layer.kubernetes_common.kubectl(
+        '-n', ns, 'get', 'serviceaccounts', '-o', 'yaml'))
+    serviceaccounts = [i['metadata']['name'] for i in y['items']]
+    action_set({'names': ', '.join(serviceaccounts)})
+    return serviceaccounts
+
+
+def sa_create():
+    ns = action_get('namespace') or 'default'
+    name = action_get('name')
+    role = action_get('role') or None
+    protect_resources(name, role)
+
+    serviceaccounts = sa_list()
+    if name in serviceaccounts:
+        action_fail('SA "{}" already exists in the "{}" namespace.'.format(name, ns))
+        return
+
+    # Create the SA and related resources
+    res_file = '/etc/kubernetes/addons/create-sa.yaml'
+    render('create-sa.yaml.j2', res_file,
+           context={'name': name, 'namespace': ns, 'role': role})
+    output = layer.kubernetes_common.kubectl('apply', '-f', res_file).decode('utf-8')
+
+    # Create a kubeconfig
+    ca_crt = layer.kubernetes_common.ca_crt_path
+    kubeconfig_path = '/home/ubuntu/{}-sa-kubeconfig'.format(name)
+    public_address, public_port = layer.kubernetes_master.get_api_endpoint()
+    public_server = 'https://{0}:{1}'.format(public_address, public_port)
+    token = layer.kubernetes_master.get_sa_token(sa=name, ns=ns)
+
+    layer.kubernetes_common.create_kubeconfig(kubeconfig_path, public_server, ca_crt,
+                                              token=token, user=name)
+    os.chmod(kubeconfig_path, 0o644)
+
+    # Tell the people what they've won
+    fetch_cmd = 'juju scp {}:{} .'.format(hookenv.local_unit(), kubeconfig_path)
+    action_set({'msg': 'SA "{}" created in the "{}" namespace.'.format(name, ns)})
+    action_set({'names': ', '.join(serviceaccounts + [name])})
+    action_set({'output': output})
+    action_set({'kubeconfig': fetch_cmd})
+
+
+def sa_delete():
+    ns = action_get('namespace') or 'default'
+    name = action_get('name')
+    protect_resources(name)
+
+    serviceaccounts = sa_list()
+    if name not in serviceaccounts:
+        action_fail('SA "{}" does not exist in the "{}" namespace.'.format(name, ns))
+        return
+
+    # Only delete SAs and RoleBindings, never Namespaces nor Roles.
+    output = layer.kubernetes_common.kubectl(
+        '-n', ns, 'delete', 'serviceaccount', name)
+    output += layer.kubernetes_common.kubectl(
+        '-n', ns, 'delete', 'rolebinding', '{}-rolebinding'.format(name))
+
+    action_set({'msg': 'SA "{}" deleted from the "{}" namespace.'.format(name, ns)})
+    action_set({'names': ', '.join(sa for sa in serviceaccounts if sa != name)})
+    action_set({'output': output.decode('utf-8')})
+
+
+action = action_name().replace('sa-', '')
+if action == 'create':
+    sa_create()
+elif action == 'list':
+    sa_list()
+elif action == 'delete':
+    sa_delete()

--- a/actions/sa-delete
+++ b/actions/sa-delete
@@ -1,0 +1,1 @@
+sa-create

--- a/actions/sa-list
+++ b/actions/sa-list
@@ -1,0 +1,1 @@
+sa-create

--- a/templates/create-sa.yaml.j2
+++ b/templates/create-sa.yaml.j2
@@ -1,0 +1,47 @@
+# K8s resources used when creating serviceaccounts
+{% if namespace != 'default' -%}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}
+  labels:
+    name: {{ namespace }}
+{% endif -%}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ name }}
+  namespace: {{ namespace }}
+automountServiceAccountToken: false
+{% if role is none -%}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ name }}-role
+  namespace: {{ namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["*"]
+{% endif -%}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ name }}-rolebinding
+  namespace: {{ namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+{%- if role is none %}
+  name: {{ name }}-role
+{% else %}
+  name: {{ role }}
+{% endif -%}
+subjects:
+- namespace: {{ namespace }}
+  kind: ServiceAccount
+  name: {{ name }}


### PR DESCRIPTION
Add actions to facilitate creating, deleting, and listing SAs along with associated rbac resources.

This was originally done as a form of user management -- admins could treat serviceaccounts as "users" and have the benefit of assigning roles and namespaces to limit cluster capabilities. From [the docs](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens):

> Service account bearer tokens are perfectly valid to use outside the cluster and can be used to create identities for long standing jobs that wish to talk to the Kubernetes API.

An identity that needs to talk to the k8s api sorta sounds like a "user", as long as you consider "users" long standing jobs.  However, also in [the docs](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#user-accounts-versus-service-accounts):

> User accounts are for humans. Service accounts are for processes, which run in pods.

That's pretty clear that SAs probably shouldn't be overloaded to mean user accounts.  For this reason, we're using secrets in 1.19 to manage users and dropping the SA actions.  This draft PR is to preserve the SA work done, just in case we get future requests for managing SAs with actions.