### PR TITLE
HACluster - Removing master services from Pacemaker and leaving to Systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 *.pyc
 placeholders/
 *.charm
+interfaces
+layers

--- a/tests/data/bundle-hacluster.yaml
+++ b/tests/data/bundle-hacluster.yaml
@@ -1,0 +1,142 @@
+description: A minimal three-machine Kubernetes cluster, appropriate for development.
+series: &series focal
+machines:
+  '0':
+    constraints: cores=2 mem=4G root-disk=16G
+    series: *series
+  '1':
+    constraints: cores=2 mem=4G root-disk=16G
+    series: *series
+  '2':
+    constraints: cores=2 mem=4G root-disk=16G
+    series: *series
+  '3':
+    constraints: cores=4 mem=4G root-disk=16G
+    series: *series
+  '4':
+  '5':
+    constraints: mem=3072M
+  '6':
+    constraints: mem=3072M
+  '7':
+    constraints: mem=3072M
+applications:
+  containerd:
+    charm: cs:~containers/containerd
+    channel: edge
+  easyrsa:
+    charm: cs:~containers/easyrsa
+    channel: edge
+    num_units: 1
+    to:
+    - '3'
+  etcd:
+    charm: cs:~containers/etcd
+    channel: edge
+    num_units: 1
+    options:
+      channel: 3.4/stable
+    to:
+    - '0'
+  flannel:
+    charm: cs:~containers/flannel
+    channel: edge
+  keystone:
+    charm: keystone
+    channel: edge
+    num_units: 1
+    options:
+      openstack-origin: distro
+      token-provider: 'fernet'
+      token-expiration: 300
+    to:
+    - '4'
+  hacluster-kubernetes-control-plane:
+    charm: cs:hacluster
+    options:
+      debug: true
+    subordinate-to:
+      - kubernetes-control-plane
+  kubernetes-control-plane:
+    charm: {{charm}}
+    constraints: cores=2 mem=4G root-disk=16G
+    expose: true
+    num_units: 3
+    options:
+      channel: 1.23/edge
+      enable-keystone-authorization: True
+      ha-cluster-vip: {{OS_VIP00}}
+    resources:
+      cni-amd64: {{cni_amd64|default("0")}}
+      cni-arm64: {{cni_arm64|default("0")}}
+      cni-s390x: {{cni_s390x|default("0")}}
+      core: 0
+      kubectl: 0
+      kube-apiserver: 0
+      kube-controller-manager: 0
+      kube-scheduler: 0
+      cdk-addons: 0
+      kube-proxy: 0
+    to:
+    - '0'
+    - '1'
+    - '2'
+  kubernetes-worker:
+    charm: cs:~containers/kubernetes-worker
+    channel: edge
+    constraints: cores=4 mem=4G root-disk=16G
+    expose: true
+    num_units: 1
+    options:
+      channel: 1.23/edge
+    to:
+    - '3'
+  keystone-mysql-router:
+    charm: mysql-router
+    channel: edge
+  mysql-innodb-cluster:
+    charm: mysql-innodb-cluster
+    channel: edge
+    num_units: 3
+    to:
+    - '5'
+    - '6'
+    - '7'
+  prometheus:
+    charm: cs:prometheus2
+    num_units: 1
+    to:
+      - '0'
+relations:
+- - kubernetes-control-plane:kube-control
+  - kubernetes-worker:kube-control
+- - kubernetes-control-plane:certificates
+  - easyrsa:client
+- - kubernetes-control-plane:etcd
+  - etcd:db
+- - kubernetes-worker:certificates
+  - easyrsa:client
+- - etcd:certificates
+  - easyrsa:client
+- - flannel:etcd
+  - etcd:db
+- - flannel:cni
+  - kubernetes-control-plane:cni
+- - flannel:cni
+  - kubernetes-worker:cni
+- - containerd:containerd
+  - kubernetes-worker:container-runtime
+- - containerd:containerd
+  - kubernetes-control-plane:container-runtime
+- - kubernetes-control-plane:prometheus
+  - prometheus:manual-jobs
+# Keystone Relations
+- - kubernetes-control-plane:keystone-credentials
+  - keystone:identity-credentials
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone-mysql-router:shared-db
+  - keystone:shared-db
+# HACluster Relations
+- - 'hacluster-kubernetes-control-plane:ha'
+  - 'kubernetes-control-plane:ha'

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,34 @@ from lightkube.models.meta_v1 import ObjectMeta
 log = logging.getLogger(__name__)
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--enable-hacluster",
+        action="store_true",
+        default=False,
+        help="run hacluster tests",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "hacluster: mark test as hacluster to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--enable-hacluster"):
+        # --enable-hacluster given in cli: do not skip hacluster tests
+        return
+    skip_hacluster = pytest.mark.skip(reason="need --enable-hacluster option to run")
+    for item in items:
+        if "hacluster" in item.keywords:
+            item.add_marker(skip_hacluster)
+
+
+@pytest.fixture
+def hacluster(request):
+    return request.config.getoption("--enable-hacluster")
+
+
 @pytest.fixture(scope="module")
 @pytest.mark.asyncio
 async def kubernetes(ops_test):

--- a/tests/integration/test_kubernetes_control_plane_integration.py
+++ b/tests/integration/test_kubernetes_control_plane_integration.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import shlex
 
 import aiohttp
+import json
+import os
 import pytest
 import time
 import yaml
@@ -72,15 +74,27 @@ async def setup_resources(ops_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test, setup_resources):
+async def test_build_and_deploy(ops_test, setup_resources, hacluster):
     log.info("Build Charm...")
     charm = await ops_test.build_charm(".")
 
     log.info("Build Bundle...")
     charm_resources = {rsc.stem.replace("-", "_"): rsc for rsc in setup_resources}
-    bundle = ops_test.render_bundle(
-        "tests/data/bundle.yaml", charm=charm, **charm_resources
-    )
+    if hacluster:
+        log.info("Using hacluster bundle")
+        vips = os.getenv("OS_VIP00", "10.5.2.204 10.5.2.205")
+        log.info("OS_VIP00: {}".format(vips))
+        bundle = ops_test.render_bundle(
+            "tests/data/bundle-hacluster.yaml",
+            charm=charm,
+            **charm_resources,
+            OS_VIP00=vips,
+        )
+
+    else:
+        bundle = ops_test.render_bundle(
+            "tests/data/bundle.yaml", charm=charm, **charm_resources
+        )
 
     log.info("Deploy Charm...")
     model = ops_test.model_full_name
@@ -206,9 +220,36 @@ async def test_pod_security_policy(ops_test, kubernetes):
     app = ops_test.model.applications["kubernetes-control-plane"]
 
     await app.set_config({"pod-security-policy": yaml.dump(test_psp)})
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60)
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=120)
     await wait_for_psp(privileged=False)
 
     await app.set_config({"pod-security-policy": ""})
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60)
+    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=120)
     await wait_for_psp(privileged=True)
+
+
+@pytest.mark.hacluster
+async def test_service_down(ops_test):
+    """Test VIP change node when master services fail"""
+    ha_unit = ops_test.model.applications["hacluster-kubernetes-control-plane"].units[0]
+    action = await ha_unit.run_action("status")
+    action = await action.wait()
+    result = json.loads(action.results["result"])
+    vip_master = result["resources"]["groups"]["grp_kubernetes-control-plane_vips"]
+    node_before = vip_master[0]["nodes"][0]["name"]
+
+    # simulate a failover on one master resource (scheduler)
+    master_machine = node_before.split("-")[-1]
+    for unit in ops_test.model.applications["kubernetes-control-plane"].units:
+        if unit.entity_id.split("/")[-1] == master_machine:
+            await unit.run("systemctl stop snap.kube-scheduler.daemon")
+            # run a hook to update status of the unit
+            await unit.run("./hooks/update-status")
+
+    # check that the resource changed node
+    action = await ha_unit.run_action("status")
+    action = await action.wait()
+    result = json.loads(action.results["result"])
+    vip_master = result["resources"]["groups"]["grp_kubernetes-control-plane_vips"]
+    node_after = vip_master[0]["nodes"][0]["name"]
+    assert node_after != node_before

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ setenv =
     PYTHONBREAKPOINT=ipdb.set_trace
     CHARM_LAYERS_DIR={toxinidir}/layers
     CHARM_INTERFACES_DIR={toxinidir}/interfaces
+passenv = OS_* TEST_*
 
 [testenv:unit]
 deps =


### PR DESCRIPTION
Currently, charm-hacluster is not fully prepared to receive kubernetes master services
for some reasons:

1. charm-hacluster doesn’t wait to receive all constraints of order and colocation necessary to
run master services without conflict. Kube-apiserver should be running in a node before
Pacemaker tries to start kube-controller-manager in the same node. [1]

2. Master services are cloned (running in all nodes) with Pacemaker and not grouped with VIP
resources, meaning that if a resource starts to fail in a node that hosts the VIP, it won’t try to
change node leaving the VIP in a unit where it’s not healthy. [2]

3. Resources added with the hacluster-interface have the `migration-threshold` set to
`INFINITY`. This means that the cluster will try to recover the service in the node forever. In a
scenario where just restarting the service is not able to recover the service, Pacemaker won’t
change the VIP to another node even if it’s grouped with the master services. [3]

Knowing those issues, the short fix proposed in this PR is to remove the master services from
Pacemaker when hacluster is present in the bundle and leave to systemd that will try to restart if
the service fails. The `atexit` checks the health of master services and if some service is not
running, it will set the node in `standby` mode and this will force migration of VIP to another
node.

To make those changes take effect, first it’s necessary to approve the layer-hacluster PR [4].

One known problem of this approach is that sometimes kubernetes-master hooks get "stuck" in
a busy loop and never exit which would affect the logic needed in `atexit`. Besides this, it could
take up to 5 minutes to identify the problem and change the VIP to another node in the cluster.
The long-term solution needs to solve problems 1, 2 and 3.  

Closes-bug: [#1929234](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1929234)

[1] https://bugs.launchpad.net/charm-hacluster/+bug/1952492
[2] https://bugs.launchpad.net/charm-interface-hacluster/+bug/1952753
[3] https://github.com/openstack/charm-interface-hacluster/blob/master/interface_hacluster/common.py#L993-L1009
[4] https://github.com/juju-solutions/layer-hacluster/pull/3 
