### PR TITLE
rename the charm itself to kubernetes-control-plane

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-name: kubernetes-master
+name: kubernetes-control-plane
 summary: The Kubernetes control plane.
 maintainers:
     - Tim Van Steenburgh <tim.van.steenburgh@canonical.com>
@@ -19,6 +19,7 @@ tags:
   - infrastructure
   - kubernetes
   - master
+  - control-plane
 subordinate: false
 series:
   - focal
@@ -32,9 +33,9 @@ provides:
     # Use of this relation is strongly discouraged as the API endpoints will be
     # provided via the kube-control relation. However, it can be used to
     # override those endpoints if you need to inject a reverse proxy between
-    # the master and workers using a charm which only supports the old MITM
+    # the control-plane and workers using a charm which only supports the old MITM
     # style relations. Note, though, that since this reverse proxy will not be
-    # visible to the master, it will not be used in any of the client or
+    # visible to the control-plane, it will not be used in any of the client or
     # component kube config files.
     interface: http
   kube-control:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,21 +7,6 @@ from lightkube import KubeConfig, Client
 from lightkube.resources.core_v1 import Namespace
 from lightkube.models.meta_v1 import ObjectMeta
 
-# Quick hack to set `trust_env=False` on the httpx client,
-# so that it ignores environment *_proxy settings.
-# Issue with lightkube here: https://github.com/gtsystem/lightkube/issues/19
-from lightkube.core.generic_client import GenericClient
-from lightkube.config.client_adapter import httpx_parameters
-from lightkube.config.kubeconfig import SingleConfig
-import httpx
-
-
-def CustomClient(config: SingleConfig, timeout: httpx.Timeout) -> httpx.Client:
-    return httpx.Client(trust_env=False, **httpx_parameters(config, timeout))
-
-
-GenericClient.AdapterClient = staticmethod(CustomClient)
-# -------------------------------------------------------------------------------------------
 
 log = logging.getLogger(__name__)
 
@@ -50,7 +35,9 @@ async def kubernetes(ops_test):
     )
     config = KubeConfig.from_file(kubeconfig_path)
     kubernetes = Client(
-        config=config.get(context_name="juju-context"), namespace=namespace
+        config=config.get(context_name="juju-context"),
+        namespace=namespace,
+        trust_env=False,
     )
     namespace_obj = Namespace(metadata=ObjectMeta(name=namespace))
     kubernetes.create(namespace_obj)

--- a/tests/validate-wheelhouse.sh
+++ b/tests/validate-wheelhouse.sh
@@ -5,4 +5,4 @@ function cleanup { rm -rf "$build_dir"; }
 trap cleanup EXIT
 
 charm build . --build-dir "$build_dir" --debug
-pip install -f "$build_dir/kubernetes-master/wheelhouse" --no-index --no-cache-dir "$build_dir"/kubernetes-master/wheelhouse/*
+pip install -f "$build_dir/kubernetes-control-plane/wheelhouse" --no-index --no-cache-dir "$build_dir"/kubernetes-control-plane/wheelhouse/*


### PR DESCRIPTION
Actual renaming of the charm.  Don't Pull without the following merged and tested
* https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/197
* https://github.com/charmed-kubernetes/jenkins/pull/744