### PR TITLE
Add support for external-cloud-provider relation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -83,6 +83,8 @@ requires:
     # Indicates that the LB should be public facing. Intended for clients which
     # must reach the API server via external networks.
     interface: loadbalancer
+  external-cloud-provider:
+    interface: external_cloud_provider
 resources:
   core:
     type: file

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1508,9 +1508,6 @@ def send_api_urls():
 @when("kube-control.connected")
 def send_xcp_flag():
     kube_control = endpoint_from_name("kube-control")
-    if not hasattr(kube_control, "set_has_xcp"):
-        # built with an old version of the kube-control interface
-        return
     kube_control.set_has_xcp(hookenv.relations()["external-cloud-provider"])
 
 
@@ -3653,13 +3650,9 @@ def configure_kubelet():
 
     registry = hookenv.config("image-registry")
     taints = hookenv.config("register-with-taints").split()
-    try:
-        kubernetes_common.configure_kubelet(
-            dns_domain, dns_ip, registry, taints=taints, has_xcp=has_xcp
-        )
-    except TypeError:
-        # older kubernetes-common doesn't support the has_xcp flag
-        kubernetes_common.configure_kubelet(dns_domain, dns_ip, registry, taints=taints)
+    kubernetes_common.configure_kubelet(
+        dns_domain, dns_ip, registry, taints=taints, has_xcp=has_xcp
+    )
     service_restart("snap.kubelet.daemon")
 
     set_flag("kubernetes-master.kubelet.configured")

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -3653,9 +3653,13 @@ def configure_kubelet():
 
     registry = hookenv.config("image-registry")
     taints = hookenv.config("register-with-taints").split()
-    kubernetes_common.configure_kubelet(
-        dns_domain, dns_ip, registry, taints=taints, has_xcp=has_xcp
-    )
+    try:
+        kubernetes_common.configure_kubelet(
+            dns_domain, dns_ip, registry, taints=taints, has_xcp=has_xcp
+        )
+    except TypeError:
+        # older kubernetes-common doesn't support the has_xcp flag
+        kubernetes_common.configure_kubelet(dns_domain, dns_ip, registry, taints=taints)
     service_restart("snap.kubelet.daemon")
 
     set_flag("kubernetes-master.kubelet.configured")

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1505,6 +1505,15 @@ def send_api_urls():
     kube_control.set_api_endpoints(kubernetes_master.get_api_urls(endpoints))
 
 
+@when("kube-control.connected")
+def send_xcp_flag():
+    kube_control = endpoint_from_name("kube-control")
+    if not hasattr(kube_control, "set_external_cloud_provider"):
+        # built with an old version of the kube-control interface
+        return
+    kube_control.set_has_xcp(hookenv.relations()["external-cloud-provider"])
+
+
 @when("certificates.available", "cni.available")
 def send_data():
     """Send the data that is required to create a server certificate for
@@ -2452,7 +2461,9 @@ def configure_apiserver():
         api_opts["client-ca-file"] = str(ca_crt_path)
 
     api_cloud_config_path = cloud_config_path("kube-apiserver")
-    if is_state("endpoint.aws.ready"):
+    if hookenv.relations()["external-cloud-provider"]:
+        api_opts["cloud-provider"] = "external"
+    elif is_state("endpoint.aws.ready"):
         api_opts["cloud-provider"] = "aws"
         feature_gates.append("CSIMigrationAWS=false")
     elif is_state("endpoint.gcp.ready"):
@@ -2629,7 +2640,9 @@ def configure_controller_manager():
         controller_opts["node-cidr-mask-size-ipv6"] = net_ipv6.prefixlen
 
     cm_cloud_config_path = cloud_config_path("kube-controller-manager")
-    if is_state("endpoint.aws.ready"):
+    if hookenv.relations()["external-cloud-provider"]:
+        controller_opts["cloud-provider"] = "external"
+    elif is_state("endpoint.aws.ready"):
         controller_opts["cloud-provider"] = "aws"
         feature_gates.append("CSIMigrationAWS=false")
     elif is_state("endpoint.gcp.ready"):
@@ -3623,6 +3636,7 @@ def configure_kubelet():
             hookenv.WARNING,
         )
         return
+    has_xcp = hookenv.relations()["external-cloud-provider"]
 
     local_endpoint = kubernetes_master.get_local_api_endpoint()
     local_url = kubernetes_master.get_api_url(local_endpoint)
@@ -3639,7 +3653,9 @@ def configure_kubelet():
 
     registry = hookenv.config("image-registry")
     taints = hookenv.config("register-with-taints").split()
-    kubernetes_common.configure_kubelet(dns_domain, dns_ip, registry, taints=taints)
+    kubernetes_common.configure_kubelet(
+        dns_domain, dns_ip, registry, taints=taints, has_xcp=has_xcp
+    )
     service_restart("snap.kubelet.daemon")
 
     set_flag("kubernetes-master.kubelet.configured")

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -1508,7 +1508,7 @@ def send_api_urls():
 @when("kube-control.connected")
 def send_xcp_flag():
     kube_control = endpoint_from_name("kube-control")
-    if not hasattr(kube_control, "set_external_cloud_provider"):
+    if not hasattr(kube_control, "set_has_xcp"):
         # built with an old version of the kube-control interface
         return
     kube_control.set_has_xcp(hookenv.relations()["external-cloud-provider"])

--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -3636,7 +3636,7 @@ def configure_kubelet():
             hookenv.WARNING,
         )
         return
-    has_xcp = hookenv.relations()["external-cloud-provider"]
+    has_xcp = bool(hookenv.relations()["external-cloud-provider"])
 
     local_endpoint = kubernetes_master.get_local_api_endpoint()
     local_url = kubernetes_master.get_api_url(local_endpoint)

--- a/tests/data/bundle-hacluster.yaml
+++ b/tests/data/bundle-hacluster.yaml
@@ -22,16 +22,16 @@ machines:
     constraints: mem=3072M
 applications:
   containerd:
-    charm: cs:~containers/containerd
+    charm: containerd
     channel: edge
   easyrsa:
-    charm: cs:~containers/easyrsa
+    charm: easyrsa
     channel: edge
     num_units: 1
     to:
     - '3'
   etcd:
-    charm: cs:~containers/etcd
+    charm: etcd
     channel: edge
     num_units: 1
     options:
@@ -39,7 +39,7 @@ applications:
     to:
     - '0'
   flannel:
-    charm: cs:~containers/flannel
+    charm: flannel
     channel: edge
   keystone:
     charm: keystone
@@ -52,7 +52,7 @@ applications:
     to:
     - '4'
   hacluster-kubernetes-control-plane:
-    charm: cs:hacluster
+    charm: hacluster
     options:
       debug: true
     subordinate-to:
@@ -82,7 +82,7 @@ applications:
     - '1'
     - '2'
   kubernetes-worker:
-    charm: cs:~containers/kubernetes-worker
+    charm: kubernetes-worker
     channel: edge
     constraints: cores=4 mem=4G root-disk=16G
     expose: true
@@ -103,7 +103,7 @@ applications:
     - '6'
     - '7'
   prometheus:
-    charm: cs:prometheus2
+    charm: prometheus2
     num_units: 1
     to:
       - '0'

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -16,16 +16,16 @@ machines:
     constraints: mem=3072M
 applications:
   containerd:
-    charm: cs:~containers/containerd
+    charm: containerd
     channel: edge
   easyrsa:
-    charm: cs:~containers/easyrsa
+    charm: easyrsa
     channel: edge
     num_units: 1
     to:
     - '1'
   etcd:
-    charm: cs:~containers/etcd
+    charm: etcd
     channel: edge
     num_units: 1
     options:
@@ -33,7 +33,7 @@ applications:
     to:
     - '0'
   flannel:
-    charm: cs:~containers/flannel
+    charm: flannel
     channel: edge
   keystone:
     charm: keystone
@@ -67,7 +67,7 @@ applications:
     to:
     - '0'
   kubernetes-worker:
-    charm: cs:~containers/kubernetes-worker
+    charm: kubernetes-worker
     channel: edge
     constraints: cores=4 mem=4G root-disk=16G
     expose: true
@@ -88,7 +88,7 @@ applications:
     - '4'
     - '5'
   prometheus:
-    charm: cs:prometheus2
+    charm: prometheus2
     num_units: 1
     to:
       - '0'


### PR DESCRIPTION
Adds an `external-cloud-provider` relation endpoint and uses that to drive the appropriate `cloud-provider=external` configs, as well as passing it through to the workers via the new `has_xcp` flag.

Depends on: 
* https://github.com/juju-solutions/interface-kube-control/pull/34
* https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/24