### PR TITLE
handle when kubelet service fails to heal

### DIFF
--- a/reactive/kubernetes_master.py
+++ b/reactive/kubernetes_master.py
@@ -3725,4 +3725,5 @@ HEAL_HANDLER = {
         "run": start_master,
         "clear_flags": ["kubernetes-master.components.started"],
     },
+    "kubelet": {"run": reconfigure_kubelet, "clear_flags": []},
 }


### PR DESCRIPTION
Addresses [LP1965765](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1965765) by giving the charm some action to take in the event the kubelet service fails to start on the control-plane node