### PR TITLE
Add calls to write the kublet config on azure and gcp

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -3092,12 +3092,14 @@ def cloud_ready():
     if is_state("endpoint.gcp.ready"):
         write_gcp_snap_config("kube-apiserver")
         write_gcp_snap_config("kube-controller-manager")
+        write_gcp_snap_config("kubelet")
     elif is_state("endpoint.vsphere.ready"):
         _write_vsphere_snap_config("kube-apiserver")
         _write_vsphere_snap_config("kube-controller-manager")
     elif is_state("endpoint.azure.ready"):
         write_azure_snap_config("kube-apiserver")
         write_azure_snap_config("kube-controller-manager")
+        write_azure_snap_config("kubelet")
     remove_state("kubernetes-control-plane.cloud.pending")
     set_state("kubernetes-control-plane.cloud.ready")
     remove_state("kubernetes-control-plane.components.started")  # force restart


### PR DESCRIPTION
When kubelet is running on control plane nodes, it needs to have a cloud config file written to its file system. [The worker charm](https://github.com/charmed-kubernetes/charm-kubernetes-worker/blob/4f3485f93152d6f836d06958cbea6a7ec7d250f2/reactive/kubernetes_worker.py#L1242-L1245) does this, but it is currently missing from the control plane charm. 

I tested this fix using GCP and can confirm it worked. I did not test on azure. 