### PR TITLE
make 1.24/stable the default channel on the stable branch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.24/stable"
     description: |
       Snap channel to install Kubernetes control plane services from
   client_password:

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -1,11 +1,11 @@
-description: A minimal two-machine Kubernetes cluster, appropriate for development.
+description: A minimal Kubernetes cluster with keystone, appropriate for development.
 series: &series focal
 machines:
   '0':
-    constraints: cores=2 mem=4G root-disk=16G
+    constraints: cores=2 mem=8G root-disk=16G
     series: *series
   '1':
-    constraints: cores=4 mem=4G root-disk=16G
+    constraints: cores=2 mem=8G root-disk=16G
     series: *series
   '2':
   '3':
@@ -17,27 +17,27 @@ machines:
 applications:
   containerd:
     charm: containerd
-    channel: latest/edge
+    channel: 1.24/stable
   easyrsa:
     charm: easyrsa
-    channel: latest/edge
+    channel: 1.24/stable
     num_units: 1
     to:
     - '1'
   etcd:
     charm: etcd
-    channel: latest/edge
+    channel: 1.24/stable
     num_units: 1
     options:
       channel: 3.4/stable
     to:
     - '0'
-  flannel:
-    charm: flannel
-    channel: latest/edge
+  calico:
+    charm: calico
+    channel: 1.24/stable
   keystone:
     charm: keystone
-    channel: latest/edge
+    channel: edge
     num_units: 1
     options:
       openstack-origin: distro
@@ -51,7 +51,7 @@ applications:
     expose: true
     num_units: 1
     options:
-      channel: 1.23/edge
+      channel: 1.24/stable
       enable-keystone-authorization: True
     resources:
       cni-amd64: {{cni_amd64|default("0")}}
@@ -68,20 +68,20 @@ applications:
     - '0'
   kubernetes-worker:
     charm: kubernetes-worker
-    channel: latest/edge
-    constraints: cores=4 mem=4G root-disk=16G
+    channel: 1.24/stable
+    constraints: cores=2 mem=8G root-disk=16G
     expose: true
     num_units: 1
     options:
-      channel: 1.23/edge
+      channel: 1.24/stable
     to:
     - '1'
   keystone-mysql-router:
     charm: mysql-router
-    channel: latest/edge
+    channel: edge
   mysql-innodb-cluster:
     charm: mysql-innodb-cluster
-    channel: latest/stable
+    channel: edge
     num_units: 3
     to:
     - '3'
@@ -89,7 +89,7 @@ applications:
     - '5'
   prometheus:
     charm: prometheus2
-    channel: latest/stable
+    channel: edge
     num_units: 1
     to:
       - '0'
@@ -104,11 +104,11 @@ relations:
   - easyrsa:client
 - - etcd:certificates
   - easyrsa:client
-- - flannel:etcd
+- - calico:etcd
   - etcd:db
-- - flannel:cni
+- - calico:cni
   - kubernetes-control-plane:cni
-- - flannel:cni
+- - calico:cni
   - kubernetes-worker:cni
 - - containerd:containerd
   - kubernetes-worker:container-runtime


### PR DESCRIPTION
- update charm config
- refactor test data to match our 1.24 architecture