### PR TITLE
Fix race condition with allow-privileged=auto when relating ceph

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -213,6 +213,14 @@ register_trigger(
     when_not="ceph-client.connected",
     clear_flag="kubernetes-control-plane.ceph.permissions.requested",
 )
+register_trigger(
+    when="ceph-client.available",
+    clear_flag="kubernetes-control-plane.apiserver.configured"
+)
+register_trigger(
+    when_not="ceph-client.available",
+    clear_flag="kubernetes-control-plane.apiserver.configured"
+)
 
 
 def set_upgrade_needed(forced=False):

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -215,11 +215,11 @@ register_trigger(
 )
 register_trigger(
     when="ceph-client.available",
-    clear_flag="kubernetes-control-plane.apiserver.configured"
+    clear_flag="kubernetes-control-plane.apiserver.configured",
 )
 register_trigger(
     when_not="ceph-client.available",
-    clear_flag="kubernetes-control-plane.apiserver.configured"
+    clear_flag="kubernetes-control-plane.apiserver.configured",
 )
 
 

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -370,9 +370,6 @@ def check_for_upgrade_needed():
             daemon = "snap.{}.daemon".format(service)
             hacluster.remove_systemd_service(service, daemon)
 
-    if is_flag_set("ceph-client.available"):
-        kubernetes_control_plane.install_ceph_common()
-
 
 @hook("pre-series-upgrade")
 def pre_series_upgrade():
@@ -392,12 +389,6 @@ def post_series_upgrade():
 @hook("leader-elected")
 def leader_elected():
     clear_flag("authentication.setup")
-
-
-@hook("ceph-client-relation-changed")
-def ceph_client_relation_changed(ceph_client):
-    if is_flag_set("ceph-client.available"):
-        kubernetes_control_plane.install_ceph_common()
 
 
 def add_rbac_roles():

--- a/tests/data/bundle-keystone.yaml
+++ b/tests/data/bundle-keystone.yaml
@@ -7,6 +7,13 @@ machines:
   '1':
     constraints: cores=4 mem=4G root-disk=16G
     series: *series
+  '2':
+  '3':
+    constraints: mem=3072M
+  '4':
+    constraints: mem=3072M
+  '5':
+    constraints: mem=3072M
 applications:
   containerd:
     charm: containerd
@@ -28,6 +35,16 @@ applications:
   flannel:
     charm: flannel
     channel: latest/edge
+  keystone:
+    charm: keystone
+    channel: latest/stable
+    num_units: 1
+    options:
+      openstack-origin: distro
+      token-provider: 'fernet'
+      token-expiration: 300
+    to:
+    - '2'
   kubernetes-control-plane:
     charm: {{charm}}
     constraints: cores=2 mem=4G root-disk=16G
@@ -35,6 +52,7 @@ applications:
     num_units: 1
     options:
       channel: 1.23/edge
+      enable-keystone-authorization: True
     resources:
       cni-amd64: {{cni_amd64|default("0")}}
       cni-arm64: {{cni_arm64|default("0")}}
@@ -58,6 +76,17 @@ applications:
       channel: 1.23/edge
     to:
     - '1'
+  keystone-mysql-router:
+    charm: mysql-router
+    channel: latest/stable
+  mysql-innodb-cluster:
+    charm: mysql-innodb-cluster
+    channel: latest/stable
+    num_units: 3
+    to:
+    - '3'
+    - '4'
+    - '5'
   prometheus:
     charm: prometheus2
     channel: latest/stable
@@ -87,3 +116,10 @@ relations:
   - kubernetes-control-plane:container-runtime
 - - kubernetes-control-plane:prometheus
   - prometheus:manual-jobs
+# Keystone Relations
+- - kubernetes-control-plane:keystone-credentials
+  - keystone:identity-credentials
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - keystone-mysql-router:shared-db
+  - keystone:shared-db

--- a/tests/data/bundle.yaml
+++ b/tests/data/bundle.yaml
@@ -37,7 +37,7 @@ applications:
     channel: latest/edge
   keystone:
     charm: keystone
-    channel: latest/edge
+    channel: latest/stable
     num_units: 1
     options:
       openstack-origin: distro
@@ -78,7 +78,7 @@ applications:
     - '1'
   keystone-mysql-router:
     charm: mysql-router
-    channel: latest/edge
+    channel: latest/stable
   mysql-innodb-cluster:
     charm: mysql-innodb-cluster
     channel: latest/stable


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1971595

When `ceph-client.available` changes, we need to reconfigure kube-apiserver since the allow-privileged flag may change. The new triggers cover this.

I also removed two unnecessary calls to `install_ceph_common()` because it's already being called [here](https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/blob/0f496a73fd0e815c67d8910aea0ffc38d45468da/reactive/kubernetes_control_plane.py#L1705). Turns out that's the better place for it anyway because it prevents a race condition where the `ceph-client-relation-changed` hook handler could run before the ceph-client interface has set `ceph-client.available`.