### PR TITLE
share service_cidr over cni relation

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2294,6 +2294,9 @@ def configure_apiserver():
     cluster_cidr = kubernetes_common.cluster_cidr()
     service_cidr = kubernetes_control_plane.service_cidr()
 
+    # Share service_cidr with cni requirers
+    endpoint_from_flag("cni.available").set_service_cidr(service_cidr)
+
     api_opts = {}
 
     if is_privileged():


### PR DESCRIPTION
Using new relation endpoint method, share the `service-cidr` over the CNI relation

Depends on merging this first
* https://github.com/juju-solutions/interface-kubernetes-cni/pull/11/files