### PR TITLE
Defaults/taints and labels

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -333,7 +333,7 @@ options:
       [1] https://github.com/kubernetes/examples/blob/master/staging/podsecuritypolicy/rbac/policies.yaml
   register-with-taints:
     type: string
-    default: "juju.is/kubernetes-control-plane=true:NoSchedule"
+    default: "node-role.kubernetes.io/control-plane=true:NoSchedule"
     description: |
       Space-separated list of taints to apply to this node at registration time.
 
@@ -356,5 +356,6 @@ options:
       For more information, see the upstream Kubernetes documentation about this 
       feature:      
       https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#enable-kubernetes-apiserver-flags
-
-
+  labels:
+    # Override default from layer-kubernetes-node-base config.yaml
+    default: "node-role.kubernetes.io/control-plane=true"

--- a/tests/data/bundle-hacluster.yaml
+++ b/tests/data/bundle-hacluster.yaml
@@ -1,4 +1,5 @@
 description: Overlay for HA Cluster deployment
+series: &series {{ series }}
 applications:
   hacluster-kubernetes-control-plane:
     charm: hacluster
@@ -10,6 +11,10 @@ applications:
     num_units: 3
     options:
       ha-cluster-vip: {{OS_VIP00}}
+      channel: {{ snap_channel }}
+  kubernetes-worker:
+    options:
+      channel: {{ snap_channel }}
 relations:
 - - 'hacluster-kubernetes-control-plane:ha'
   - 'kubernetes-control-plane:ha'

--- a/tests/data/bundle-keystone.yaml
+++ b/tests/data/bundle-keystone.yaml
@@ -1,4 +1,5 @@
 description: Overlay for testing with keystone
+series: &series {{ series }}
 applications:
   keystone:
     charm: keystone
@@ -11,6 +12,11 @@ applications:
   kubernetes-control-plane:
     options:
       enable-keystone-authorization: True
+    options:
+      channel: {{ snap_channel }}
+  kubernetes-worker:
+    options:
+      channel: {{ snap_channel }}
   keystone-mysql-router:
     charm: mysql-router
     channel: latest/stable

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -1,4 +1,5 @@
 description: Overlay for attaching current charm
+series: &series {{ series }}
 applications:
   kubernetes-control-plane:
     charm: {{charm}}
@@ -14,6 +15,11 @@ applications:
       kube-scheduler: 0
       cdk-addons: 0
       kube-proxy: 0
+    options:
+      channel: {{ snap_channel }}
+  kubernetes-worker:
+    options:
+      channel: {{ snap_channel }}
   prometheus:
     charm: prometheus2
     channel: latest/stable

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,6 +26,30 @@ def pytest_addoption(parser):
         help="run keystone tests",
     )
 
+    parser.addoption(
+        "--series",
+        type=str,
+        default="focal",
+        help="Set series for the machine units",
+    )
+
+    parser.addoption(
+        "--snap-channel",
+        type=str,
+        default="1.24/stable",
+        help="Set snap channel for the control-plane & worker units",
+    )
+
+
+@pytest.fixture()
+def series(request):
+    return request.config.getoption("--series")
+
+
+@pytest.fixture()
+def snap_channel(request):
+    return request.config.getoption("--snap-channel")
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "hacluster: mark test as hacluster to run")

--- a/tests/integration/test_kubernetes_control_plane_integration.py
+++ b/tests/integration/test_kubernetes_control_plane_integration.py
@@ -29,7 +29,7 @@ def _check_status_messages(ops_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test, hacluster, keystone):
+async def test_build_and_deploy(ops_test, hacluster, keystone, series, snap_channel):
     log.info("Build Charm...")
     charm = await ops_test.build_charm(".")
 
@@ -47,7 +47,7 @@ async def test_build_and_deploy(ops_test, hacluster, keystone):
 
     assert resources, "Failed to build or download charm resources."
 
-    context = dict(charm=charm, **resources)
+    context = dict(charm=charm, series=series, snap_channel=snap_channel, **resources)
     overlays = [
         ops_test.Bundle("kubernetes-core", channel="edge"),
         Path("tests/data/charm.yaml"),


### PR DESCRIPTION
Update taint and labels to match upstream definition for these nodes
https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-control-plane