### PR TITLE
Update series/snap channels to be pulled from bundle if not specified

### DIFF
--- a/tests/integration/test_kubernetes_control_plane_integration.py
+++ b/tests/integration/test_kubernetes_control_plane_integration.py
@@ -30,7 +30,9 @@ def _check_status_messages(ops_test):
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_build_and_deploy(ops_test, hacluster, keystone, series, snap_channel):
+async def test_build_and_deploy(
+    ops_test, hacluster, keystone, k8s_core_bundle, series, snap_channel
+):
     log.info("Build Charm...")
     charm = await ops_test.build_charm(".")
 
@@ -50,7 +52,7 @@ async def test_build_and_deploy(ops_test, hacluster, keystone, series, snap_chan
 
     context = dict(charm=charm, series=series, snap_channel=snap_channel, **resources)
     overlays = [
-        ops_test.Bundle("kubernetes-core", channel="edge"),
+        k8s_core_bundle,
         Path("tests/data/charm.yaml"),
     ]
 


### PR DESCRIPTION
This PR updates the the snap channel and series command line arguments added previously to pull default values from the kubernetes core bundle. 

Unfortunately you cannot use fixtures in pytest hooks, so the default value of the command line argument was changed to an empty string, and a check was added to the series and snap channel fixtures to pull from the bundle if this option was empty. 