### PR TITLE
Append CSIMigrationvsPhere feature gate

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2459,6 +2459,7 @@ def configure_apiserver():
     ):
         api_opts["cloud-provider"] = "vsphere"
         api_opts["cloud-config"] = str(api_cloud_config_path)
+        feature_gates.append("CSIMigrationvSphere=false")
     elif is_state("endpoint.azure.ready"):
         api_opts["cloud-provider"] = "azure"
         api_opts["cloud-config"] = str(api_cloud_config_path)
@@ -2638,6 +2639,7 @@ def configure_controller_manager():
     ):
         controller_opts["cloud-provider"] = "vsphere"
         controller_opts["cloud-config"] = str(cm_cloud_config_path)
+        feature_gates.append("CSIMigrationvSphere=false")
     elif is_state("endpoint.azure.ready"):
         controller_opts["cloud-provider"] = "azure"
         controller_opts["cloud-config"] = str(cm_cloud_config_path)
@@ -2672,6 +2674,11 @@ def configure_scheduler():
         feature_gates.append("CSIMigrationGCE=false")
     elif is_state("endpoint.azure.ready"):
         feature_gates.append("CSIMigrationAzureDisk=false")
+    elif is_state("endpoint.vsphere.ready") and get_version("kube-apiserver") >= (
+        1,
+        12,
+    ):
+        feature_gates.append("CSIMigrationvSphere=false")
 
     scheduler_opts["feature-gates"] = ",".join(feature_gates)
 


### PR DESCRIPTION
Adds `CSIMigrationvsPhere=false` to the feature gates for controller, scheduler, and api server. This allows the in-tree vsphere provider to create storage in 1.25+, but this flag is also desirable in lower versions as well. 