### PR TITLE
make 1.25/stable the default snap channel for release_1.25

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -107,7 +107,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.25/stable"
     description: |
       Snap channel to install Kubernetes control plane services from
   client_password:


### PR DESCRIPTION
In preparation for the 1.25 release, make 1.25/stable the default snap channel in the release branch.