### PR TITLE
[1.25] Add flit-core<4 as a wheelhouse.txt requirement for building idna wheel

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -2,3 +2,8 @@ aiohttp>=3.7.4,<3.8.0
 gunicorn>=20.0.0,<21.0.0
 loadbalancer-interface
 typing_extensions<4.0
+
+# idna>=3.4 and beyond (needed by aiohttp and hvac)
+# requires flit-core for building its wheel.
+# it's not just included for fun
+flit-core<4


### PR DESCRIPTION
Cherry-pick of https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/246 to the release_1.25 branch