### PR TITLE
Remove IPv6DualStack feature gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,18 @@ jobs:
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
       - name: Run test
         run: tox -e integration
+      - name: Setup Debug Artifact Collection
+        if: ${{ failure() }}
+        run: mkdir tmp
+      - name: Collect Juju Status
+        if: ${{ failure() }}
+        run: |
+          juju status 2>&1 | tee tmp/juju-status.txt
+          juju-crashdump -s -m controller -a debug-layer -a config -o tmp/
+          mv juju-crashdump-* tmp/ | true
+      - name: Upload debug artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-run-artifacts
+          path: tmp

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2327,8 +2327,6 @@ def configure_apiserver():
     # Handle static options for now
     api_opts["service-cluster-ip-range"] = service_cidr
     feature_gates = []
-    if kubernetes_common.is_dual_stack(cluster_cidr):
-        feature_gates.append("IPv6DualStack=true")
     api_opts["min-request-timeout"] = "300"
     api_opts["v"] = "4"
     api_opts["tls-cert-file"] = str(server_crt_path)
@@ -2619,8 +2617,6 @@ def configure_controller_manager():
     controller_opts["service-cluster-ip-range"] = service_cidr
     controller_opts["cluster-cidr"] = cluster_cidr
     feature_gates = ["RotateKubeletServerCertificate=true"]
-    if kubernetes_common.is_dual_stack(cluster_cidr):
-        feature_gates.append("IPv6DualStack=true")
     net_ipv6 = kubernetes_common.get_ipv6_network(cluster_cidr)
     if net_ipv6:
         controller_opts["node-cidr-mask-size-ipv6"] = net_ipv6.prefixlen


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1990455

The IPv6DualStack feature gate was removed in k8s 1.25 ([source](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#other-cleanup-or-flake)). Setting the feature gate now causes k8s services to fail.

This feature has been enabled by default since k8s 1.21 and GA since k8s 1.23 ([source](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)) so we shouldn't need to worry about backwards compatibility with this change.