### PR TITLE
Addition of pip==20.0.2 and psutil==5.9.2

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -3,6 +3,13 @@ gunicorn>=20.0.0,<21.0.0
 loadbalancer-interface
 typing_extensions<4.0
 
+# psutil 5.9.3 starts requirement of setuptools>=43
+# either we use this
+# psutil<5.9.3
+# or we use the default install in focal
+# setuptools>=45.2.0
+setuptools>=45.2.0
+
 # idna>=3.4 and beyond (needed by aiohttp and hvac)
 # requires flit-core for building its wheel.
 # flit-core can run on python3.6, but requires pip 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -5,5 +5,9 @@ typing_extensions<4.0
 
 # idna>=3.4 and beyond (needed by aiohttp and hvac)
 # requires flit-core for building its wheel.
-# it's not just included for fun
+# flit-core can run on python3.6, but requires pip 
+# to be upgrade to at least 20.0.2 (same as on focal)
+#
+# These are not just included for fun.
 flit-core<4
+pip>=20.0.2

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -3,18 +3,18 @@ gunicorn>=20.0.0,<21.0.0
 loadbalancer-interface
 typing_extensions<4.0
 
-# psutil 5.9.3 starts requirement of setuptools>=43
-# either we use this
-# psutil<5.9.3
-# or we use the default install in focal
-# setuptools>=45.2.0
-setuptools>=45.2.0
-
 # idna>=3.4 and beyond (needed by aiohttp and hvac)
 # requires flit-core for building its wheel.
+# 
 # flit-core can run on python3.6, but requires pip 
-# to be upgrade to at least 20.0.2 (same as on focal)
+# be upgraded to at least 20.0.2 (same as on focal)
 #
-# These are not just included for fun.
+# psutil 5.9.3 added requirement of setuptools>=43
+# setuptools 45.2.0 is the focal default
+# 
+# layer-basic pins-back pip and setuptools
+# for full compatability in bionic, but we can push
+# those packages forward if testing shows it operates
 flit-core<4
 pip>=20.0.2
+setuptools>=45.2.0

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -9,12 +9,11 @@ typing_extensions<4.0
 # flit-core can run on python3.6, but requires pip 
 # be upgraded to at least 20.0.2 (same as on focal)
 #
-# psutil 5.9.3 added requirement of setuptools>=43
-# setuptools 45.2.0 is the focal default
+flit-core<4
+pip==20.0.2  # necessary for bionic
+
+# psutil>=5.9.3 added requirement of setuptools>=43
 # 
 # layer-basic pins-back pip and setuptools
-# for full compatability in bionic, but we can push
-# those packages forward if testing shows it operates
-flit-core<4
-pip>=20.0.2
-setuptools>=45.2.0
+# for full compatability with bionic
+psutil==5.9.2


### PR DESCRIPTION
In order to facilitate the charm installation of flit-core, pip version 20.0.2 is necessary See [LP#1991957](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1991957) for details