### PR TITLE
Don't reconfigure kube-apiserver when enable-metrics changes

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -616,20 +616,6 @@ def send_cohorts():
     set_flag("kubernetes-control-plane.cohorts.sent")
 
 
-@when("etcd.available")
-@when("config.changed.enable-metrics")
-def enable_metric_changed():
-    """
-    Trigger an api server update.
-
-    :return: None
-    """
-    clear_flag("kubernetes-control-plane.apiserver.configured")
-
-    if is_state("leadership.is_leader"):
-        configure_cdk_addons()
-
-
 @when("config.changed.client_password", "leadership.is_leader")
 def password_changed():
     """Handle password change by reconfiguring authentication."""


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1995139

Reconfiguring kube-apiserver leads to disrupted access to the Kubernetes API. Don't reconfigure it, because nothing in the config actually changes.

This whole handler can be removed because `configure_cdk_addons` runs on every hook anyways.