### PR TITLE
Remove `kube-dns` from `dns-providers`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,9 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Setup operator environment
@@ -52,7 +52,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-run-artifacts
           path: tmp

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Setup operator environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
@@ -52,7 +52,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: test-run-artifacts
           path: tmp

--- a/config.yaml
+++ b/config.yaml
@@ -58,14 +58,12 @@ options:
     type: string
     default: "auto"
     description: |
-      DNS provider addon to use. Can be "auto", "core-dns", "kube-dns", or
-      "none".
+      DNS provider addon to use. Can be "auto", "core-dns", or "none".
 
       CoreDNS is only supported on Kubernetes 1.14+.
 
       When set to "auto", the behavior is as follows:
       - New deployments of Kubernetes 1.14+ will use CoreDNS
-      - New deployments of Kubernetes 1.13 or older will use KubeDNS
       - Upgraded deployments will continue to use whichever provider was
       previously used.
   dns_domain:

--- a/docs/index.md
+++ b/docs/index.md
@@ -228,14 +228,12 @@ related to kubernetes-master, in which case token auth is used.
 <a id="dns-provider-description"> </a>
 **Description:**
 
-DNS provider addon to use. Can be "auto", "core-dns", "kube-dns", or
-"none".
+DNS provider addon to use. Can be "auto", "core-dns", or "none".
 
 CoreDNS is only supported on Kubernetes 1.14+.
 
 When set to "auto", the behavior is as follows:
 -   New deployments of Kubernetes 1.14+ will use CoreDNS
--   New deployments of Kubernetes 1.13 or older will use KubeDNS
 -   Upgraded deployments will continue to use whichever provider was
 previously used.
 

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -3354,8 +3354,7 @@ def get_dns_provider():
         # On new deployments, the first time this is called, auto_dns_provider
         # hasn't been set yet. We need to make a choice now.
         if not dns_provider:
-            if "core-dns" in valid_dns_providers:
-                dns_provider = "core-dns"
+            dns_provider = "core-dns"
 
     # LP: 1833089. Followers end up here when setting final status; ensure only
     # leaders call leader_set.

--- a/tests/integration/test_kubernetes_control_plane_integration.py
+++ b/tests/integration/test_kubernetes_control_plane_integration.py
@@ -85,7 +85,7 @@ async def test_build_and_deploy(
     )
 
     try:
-        await ops_test.model.wait_for_idle(wait_for_active=True, timeout=60 * 60)
+        await ops_test.model.wait_for_idle(status="active", timeout=60 * 60)
     except asyncio.TimeoutError:
         if "kubernetes-control-plane" not in ops_test.model.applications:
             raise
@@ -109,7 +109,7 @@ async def test_kube_api_endpoint(ops_test):
         "kubernetes-control-plane:kube-api-endpoint",
         "kubernetes-worker:kube-api-endpoint",
     )
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
+    await ops_test.model.wait_for_idle(status="active", timeout=10 * 60)
     _check_status_messages(ops_test)
 
 
@@ -144,7 +144,7 @@ async def test_auth_load(ops_test):
     await app.set_config({"authn-webhook-endpoint": url})
 
     log.info("Waiting for model to settle")
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60)
+    await ops_test.model.wait_for_idle(status="active", timeout=10 * 60)
 
     async def _auth_req(token, timeout=30):
         url = f"https://{unit.public_address}:5000/v1beta1"
@@ -202,11 +202,11 @@ async def test_pod_security_policy(ops_test, kubernetes, snap_channel):
     app = ops_test.model.applications["kubernetes-control-plane"]
 
     await app.set_config({"pod-security-policy": yaml.dump(test_psp)})
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=120)
+    await ops_test.model.wait_for_idle(status="active", timeout=120)
     await wait_for_psp(privileged=False)
 
     await app.set_config({"pod-security-policy": ""})
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=120)
+    await ops_test.model.wait_for_idle(status="active", timeout=120)
     await wait_for_psp(privileged=True)
 
 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -11,6 +11,7 @@ typing_extensions<4.0
 #
 flit-core<4
 pip==20.0.2  # necessary for bionic
+setuptools<46.0.0;python_version == '3.8'
 
 # psutil>=5.9.3 added requirement of setuptools>=43
 # 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -11,7 +11,9 @@ typing_extensions<4.0
 #
 flit-core<4
 pip==20.0.2  # necessary for bionic
-setuptools<46.0.0;python_version == '3.8'
+# pin setuptools to circumvent the build/run bug in >= focal
+# https://discourse.charmhub.io/t/cannot-install-dependencies-modulenotfounderror-no-module-named-setuptools-command-build/7374
+setuptools==45.2.0;python_version >= '3.8'
 
 # psutil>=5.9.3 added requirement of setuptools>=43
 # 

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -11,9 +11,6 @@ typing_extensions<4.0
 #
 flit-core<4
 pip==20.0.2  # necessary for bionic
-# pin setuptools to circumvent the build/run bug in >= focal
-# https://discourse.charmhub.io/t/cannot-install-dependencies-modulenotfounderror-no-module-named-setuptools-command-build/7374
-setuptools==45.2.0;python_version >= '3.8'
 
 # psutil>=5.9.3 added requirement of setuptools>=43
 # 


### PR DESCRIPTION
## Purpose
Kube-DNS is included in K8s Legacy addons. We should remove it now that deployment on 1.25+ does not work.
## Changes
- Remove `Kube DNS` from the valid dns providers.
- Modify config.yaml to reflect the new providers list.
- Update README to reflect the changes.