### PR TITLE
presence of text in `stderr` in kubectl don't necessarily represent a failed command.

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2587,7 +2587,9 @@ def configure_controller_manager():
         controller_opts["logtostderr"] = "true"
     if get_version("kube-controller-manager") >= (1, 26):
         controller_opts["requestheader-client-ca-file"] = str(ca_crt_path)
-        controller_opts["requestheader-allowed-names"] = "system:kube-controller-manager,client"
+        controller_opts[
+            "requestheader-allowed-names"
+        ] = "system:kube-controller-manager,client"
     controller_opts["kubeconfig"] = kubecontrollermanagerconfig_path
     controller_opts["authorization-kubeconfig"] = kubecontrollermanagerconfig_path
     controller_opts["authentication-kubeconfig"] = kubecontrollermanagerconfig_path

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2585,11 +2585,6 @@ def configure_controller_manager():
     controller_opts["root-ca-file"] = str(ca_crt_path)
     if get_version("kube-controller-manager") < (1, 26, 0):
         controller_opts["logtostderr"] = "true"
-    if get_version("kube-controller-manager") >= (1, 26):
-        controller_opts["requestheader-client-ca-file"] = str(ca_crt_path)
-        controller_opts[
-            "requestheader-allowed-names"
-        ] = "system:kube-controller-manager,client"
     controller_opts["kubeconfig"] = kubecontrollermanagerconfig_path
     controller_opts["authorization-kubeconfig"] = kubecontrollermanagerconfig_path
     controller_opts["authentication-kubeconfig"] = kubecontrollermanagerconfig_path

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2585,6 +2585,9 @@ def configure_controller_manager():
     controller_opts["root-ca-file"] = str(ca_crt_path)
     if get_version("kube-controller-manager") < (1, 26, 0):
         controller_opts["logtostderr"] = "true"
+    if get_version("kube-controller-manager") >= (1, 26):
+        controller_opts["requestheader-client-ca-file"] = str(ca_crt_path)
+        controller_opts["requestheader-allowed-names"] = "system:kube-controller-manager,client"
     controller_opts["kubeconfig"] = kubecontrollermanagerconfig_path
     controller_opts["authorization-kubeconfig"] = kubecontrollermanagerconfig_path
     controller_opts["authentication-kubeconfig"] = kubecontrollermanagerconfig_path

--- a/templates/cdk.master.auth-webhook.py
+++ b/templates/cdk.master.auth-webhook.py
@@ -348,9 +348,13 @@ async def refresh_secrets(app):
         'get', 'secrets', '-n', 'kube-system', '-o', 'json'
     )
     # See note in run() docstring above about exit 255.
-    if retcode not in (0, 255) or stderr:
-        app.logger.warning('Unable to load secrets ({}): {}'.format(retcode, stderr))
+    if retcode not in (0, 255):
+        app.logger.error('Unable to load secrets ({}): {}'.format(retcode, stderr))
         return
+    elif stderr:
+        # kubectl can present with errors, but still yield 
+        # valid secrets, let's try at least to parse stdout
+        app.logger.warning('Errors loading secrets ({}): {}'.format(retcode, stderr))
 
     try:
         secrets = json.loads(stdout)


### PR DESCRIPTION
While testing changed for containerd, it was discovered that 1.26/edge builds of kubectl presented with errors but completed successfully. There was `stderr` content while still fulfilling the requested command.  If `retcode == 0` but `stderr` had contents, the `auth-webhook` would fail without need. 