### PR TITLE
remove in-tree storage class definitions (AWS, GCE, and Azure)

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -1733,9 +1733,13 @@ def configure_cdk_addons():
     else:
         keystoneEnabled = "false"
 
-    enable_aws = str(is_flag_set("endpoint.aws.ready")).lower()
-    enable_azure = str(is_flag_set("endpoint.azure.ready")).lower()
-    enable_gcp = str(is_flag_set("endpoint.gcp.ready")).lower()
+    # cdk-addons storage classes
+    if get_version("kube-apiserver") < (1, 25, 0):
+        enable_aws = str(is_flag_set("endpoint.aws.ready")).lower()
+        enable_azure = str(is_flag_set("endpoint.azure.ready")).lower()
+        enable_gcp = str(is_flag_set("endpoint.gcp.ready")).lower()
+    else:
+        enable_aws = enable_azure = enable_gcp = "false"
     enable_openstack = str(is_flag_set("endpoint.openstack.ready")).lower()
     openstack = endpoint_from_flag("endpoint.openstack.ready")
 


### PR DESCRIPTION
Starting in 1.25, the following in-tree storage classes could no longer be used, yet -- [cdk-addons still added them](https://github.com/charmed-kubernetes/cdk-addons/blob/9a72d030752d522e40f084ff0c9720b81a28be70/cdk-addons/apply#L187-L195) to the cluster.  

Let's just not enable them anymore