### PR TITLE
juju 3.0 renames the runner binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
+          juju-channel: 2.9/stable
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"

--- a/.wokeignore
+++ b/.wokeignore
@@ -1,1 +1,4 @@
 docs/
+
+# wokeignore:rule=master
+templates/cdk.master.leader.file-watcher.*

--- a/templates/cdk.master.leader.file-watcher.service
+++ b/templates/cdk.master.leader.file-watcher.service
@@ -4,9 +4,8 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c \
-    '/usr/bin/juju-exec {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh || \
-    /usr/bin/juju-run {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh'
+ExecStart=-/usr/bin/juju-exec {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh
+ExecStart=-/usr/bin/juju-run {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/cdk.master.leader.file-watcher.service
+++ b/templates/cdk.master.leader.file-watcher.service
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/juju-run {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh
+ExecStart=-/usr/bin/juju-exec {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh
+ExecStart=-/usr/bin/juju-run {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/cdk.master.leader.file-watcher.service
+++ b/templates/cdk.master.leader.file-watcher.service
@@ -4,8 +4,9 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=-/usr/bin/juju-exec {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh
-ExecStart=-/usr/bin/juju-run {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh
+ExecStart=/bin/bash -c \
+    '/usr/bin/juju-exec {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh || \
+    /usr/bin/juju-run {{ unit }} /usr/local/sbin/cdk.master.leader.file-watcher.sh'
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/cdk.master.leader.file-watcher.sh
+++ b/templates/cdk.master.leader.file-watcher.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # This script is invoked by cdk.master.leader.file-watcher.service
-
-if [ is-leader ]; then
+if [ $("is-leader") = "False" ];
   leader-set \
     "/root/cdk/basic_auth.csv=$(cat /root/cdk/basic_auth.csv)" \
     "/root/cdk/known_tokens.csv=$(cat /root/cdk/known_tokens.csv)" \

--- a/templates/cdk.master.leader.file-watcher.sh
+++ b/templates/cdk.master.leader.file-watcher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script is invoked by cdk.master.leader.file-watcher.service
-if [ $("is-leader") = "False" ];
+if [ $("is-leader") = "True" ];
   leader-set \
     "/root/cdk/basic_auth.csv=$(cat /root/cdk/basic_auth.csv)" \
     "/root/cdk/known_tokens.csv=$(cat /root/cdk/known_tokens.csv)" \

--- a/templates/cdk.master.leader.file-watcher.sh
+++ b/templates/cdk.master.leader.file-watcher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script is invoked by cdk.master.leader.file-watcher.service
-if [ $("is-leader") = "True" ];
+if [ $("is-leader") = "True" ]; then
   leader-set \
     "/root/cdk/basic_auth.csv=$(cat /root/cdk/basic_auth.csv)" \
     "/root/cdk/known_tokens.csv=$(cat /root/cdk/known_tokens.csv)" \

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     aiohttp
     ipdb
     lightkube
-    juju < 3.0
+    juju < 3.1
 commands = 
     pytest --tb native \
            --asyncio-mode=auto \

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ deps =
     aiohttp
     ipdb
     lightkube
+    juju < 3.0
 commands = 
     pytest --tb native \
            --asyncio-mode=auto \


### PR DESCRIPTION
This service responds to a systemctl daemon which watches a set of files on the leader unit, and syncs them to other units in the cluster.

These changes ensure one of the binaries is appropriately called

Fixes: [LP:2006977](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2006977)