### PR TITLE
test control-plane charm on juju 2.9 and 3.0 controllers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
     needs:
       - lint-unit
 
-  resources-build:
-    name: Build Resources with docker
+  build-dependencies:
+    name: Build Charm and Resources
     runs-on: ubuntu-22.04
     needs:
       - lint-unit
@@ -31,7 +31,7 @@ jobs:
       - name: Install Docker
         run:  sudo snap install docker --channel=stable
       - name: Install Charm
-        run:  sudo snap install charm --channel=3.x/stable
+        run:  sudo snap install charm --channel=3.x/stable --classic
       - name: Build Charm
         run:  charm build . -F
       - name: Build Resources
@@ -52,7 +52,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 360
     needs:
-      - resources-build
+      - build-dependencies
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,18 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Install Docker
-        run:  sudo snap install docker
+        run:  sudo snap install docker --channel=stable
+      - name: Install Charm
+        run:  sudo snap install charm --channel=3.x/stable
+      - name: Build Charm
+        run:  charm build . -F
       - name: Build Resources
         run:  sudo ./build-cni-resources.sh
+      - name: Upload charm artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: charm
+          path: ./*.charm
       - name: Upload resource artifact
         uses: actions/upload-artifact@v3
         with:
@@ -61,6 +70,11 @@ jobs:
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
+
+      - name: Download charm artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: charm
 
       - name: Download resource artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
           name: cni-resources
 
       - name: Run test
-        run: tox -e integration
+        run: tox -e integration -- --basetemp=/home/ubuntu/pytest
 
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,25 +22,32 @@ jobs:
 
   build-dependencies:
     name: Build Charm and Resources
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs:
       - lint-unit
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Install Docker
-        run:  sudo snap install docker --channel=stable
-      - name: Install Charm
-        run:  sudo snap install charm --channel=3.x/stable --classic
+
+      - name: Install Snaps
+        run: |
+          sudo apt update
+          sudo apt install python3-virtualenv -y
+          sudo snap install docker --channel=stable
+          sudo snap install charm --channel=2.x/stable --classic
+
       - name: Build Charm
         run:  charm build . -F
+
       - name: Build Resources
         run:  sudo ./build-cni-resources.sh
+
       - name: Upload charm artifact
         uses: actions/upload-artifact@v3
         with:
           name: charm
           path: ./*.charm
+
       - name: Upload resource artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,17 +20,39 @@ jobs:
     needs:
       - lint-unit
 
+  resources-build:
+    name: Build Resources with docker
+    runs-on: ubuntu-22.04
+    needs:
+      - lint-unit
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Install Docker
+        run:  sudo snap install docker
+      - name: Build Resources
+        run:  sudo ./build-cni-resources.sh
+      - name: Upload resource artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cni-resources
+          path: ./cni*.tgz
+
   integration-test:
     name: Integration test with VMWare
     runs-on: self-hosted
     timeout-minutes: 360
+    needs:
+      - resources-build
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -39,17 +61,26 @@ jobs:
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
+
+      - name: Download resource artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: cni-resources
+
       - name: Run test
         run: tox -e integration
+
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp
+
       - name: Collect Juju Status
         if: ${{ failure() }}
         run: |
           juju status 2>&1 | tee tmp/juju-status.txt
           juju-crashdump -s -m controller -a debug-layer -a config -o tmp/
           mv juju-crashdump-* tmp/ | true
+
       - name: Upload debug artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,9 @@ jobs:
     timeout-minutes: 360
     needs:
       - build-dependencies
+    strategy:
+      matrix:
+        juju: ['2.9', '3.0']
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -66,10 +69,11 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
+          juju-channel: ${{ matrix.juju }}/stable
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
-          bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
+          bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
 
       - name: Download charm artifacts
         uses: actions/download-artifact@v3

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands = {toxinidir}/tests/validate-wheelhouse.sh
 [testenv:integration]
 deps =
     pytest
-    pytest-operator
+    git+https://github.com/charmed-kubernetes/pytest-operator@issue/92/tox-confinement
     aiohttp
     ipdb
     lightkube

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands = {toxinidir}/tests/validate-wheelhouse.sh
 [testenv:integration]
 deps =
     pytest
-    git+https://github.com/charmed-kubernetes/pytest-operator@issue/92/tox-confinement
+    pytest-operator
     aiohttp
     ipdb
     lightkube


### PR DESCRIPTION
Use github runner resources to build the charm and its resources
Using this split of responsibilities, allow the tests to use charm and resources from the cwd during test runs

* depends on https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/267
* depends on https://github.com/charmed-kubernetes/pytest-operator/pull/100
