### PR TITLE
Modify Pod phase check for `kube-system` pods

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2761,12 +2761,16 @@ def get_kube_system_pods_not_running():
         )
     )
 
+    # Pods in phases such as ['Running', 'Succeeded', 'Failed']
+    # should not be considered as pending Pods.
+    valid_phases = ["Running", "Succeeded", "Failed"]
+
     # Pods that are Running or Evicted (which should re-spawn) are
     # considered running
     not_running = [
         pod
         for pod in result["items"]
-        if pod["status"]["phase"] != "Running"
+        if pod["status"]["phase"] not in valid_phases
         and pod["status"].get("reason", "") != "Evicted"
     ]
 


### PR DESCRIPTION
## Rationale
This Pull Request aims to solve the issue of Kubernetes Control Plane getting stuck in the `Waiting`state when other deployed workloads have results that do not necessarily indicate a problem. In this case, resources such as Jobs, CronJobs, and others may generate the states `Succeeded` or `Failed`.

## Changes
- Include the allowed phases list in the method.
- Create unit test.

## Related Bugs
[LP#1903055](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1903055)
[LP#2006957](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2006957)