### PR TITLE
sane perms on file-watcher; stop propagating unused CSVs

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -1082,7 +1082,7 @@ def add_systemd_file_watcher():
         "cdk.master.leader.file-watcher.sh",
         "/usr/local/sbin/cdk.master.leader.file-watcher.sh",
         {},
-        perms=0o777,
+        perms=0o755,
     )
     render(
         "cdk.master.leader.file-watcher.service",

--- a/templates/cdk.master.leader.file-watcher.path
+++ b/templates/cdk.master.leader.file-watcher.path
@@ -1,6 +1,4 @@
 [Path]
-PathChanged=/root/cdk/basic_auth.csv
-PathChanged=/root/cdk/known_tokens.csv
 PathChanged=/root/cdk/serviceaccount.key
 
 [Install]


### PR DESCRIPTION
CK has used a webhook + secrets for authn since 1.19.  Stop sync'ing old file-based authn data around control-plane peers.  Also drop group/other write-privs from the file-watcher script.