### PR TITLE
Update default channel config to 1.27/edge

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.23/edge"
+    default: "1.27/edge"
     description: |
       Snap channel to install Kubernetes control plane services from
   client_password:


### PR DESCRIPTION
Kinda fixes https://bugs.launchpad.net/bugs/2007162

1.23/edge is quite out of date, and some deployments are picking up this default. Update it to something more appopriate for edge builds from the main branch.