### PR TITLE
Remove "Waiting for workers." status

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -843,14 +843,6 @@ def set_final_status():
                 hookenv.status_set("waiting", "Waiting for " + lb_endpoint)
                 return
 
-    if not is_state("kube-control.connected"):
-        if "kube-control" in goal_state.get("relations", {}):
-            status = "waiting"
-        else:
-            status = "blocked"
-        hookenv.status_set(status, "Waiting for workers.")
-        return
-
     ks = endpoint_from_flag("keystone-credentials.available")
     if ks and ks.api_version() == "2":
         msg = "Keystone auth v2 detected. v3 is required."


### PR DESCRIPTION
This status made sense when no workers meant no Kubernetes nodes. Now that kubernetes-control-plane units are proper Kubernetes nodes, it no longer makes sense to have this status.

We are running into this with Cluster API testing when we have only a single control plane node and no workers.