### PR TITLE
Fix wheelhouse failures on ops 2.1.0

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -18,3 +18,6 @@ pip==20.0.2  # necessary for bionic
 # layer-basic pins-back pip and setuptools
 # for full compatability with bionic
 psutil==5.9.2
+
+# avoid ops 2.1.0 which had a broken setup that kills pip
+ops!=2.1.0


### PR DESCRIPTION
Fix this error during validate-wheelhouse:
```
Collecting ops>=1.0.0
  Downloading ops-2.1.0.tar.gz (228 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 229.0/229.0 kB 50.0 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      Traceback (most recent call last):
        File "/tmp/tmpw5g9lv2z/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/tmp/tmpw5g9lv2z/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/tmp/tmpw5g9lv2z/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-r5ecrv03/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-r5ecrv03/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-r5ecrv03/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 484, in run_setup
          super(_BuildMetaLegacyBackend,
        File "/tmp/pip-build-env-r5ecrv03/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 90, in <module>
        File "<string>", line 34, in _requirements
      FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-download-c43jn8sh/ops_eba87aca1e4243608ba82dcdb75fdb5b/requirements.txt'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```

We're not picking up ops 2.1.1 yet because it [requires PyYAML 6.*](https://github.com/canonical/operator/blob/2.1.1/requirements.txt#L1), but layer-basic [requires PyYAML<5.4](https://github.com/juju-solutions/layer-basic/blob/edec607e05812df8d226b4aed71d09373767c0d7/wheelhouse.txt#L14). Pip tries to walk back to 2.1.0, which fails because it [had a broken setup.py](https://github.com/canonical/operator/issues/913).

Fix it by excluding ops 2.1.0. We'll end up with 2.0.0 instead.