### PR TITLE
Add config option to ignore missing CNI and enter active status 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -310,9 +310,8 @@ options:
     type: boolean
     default: false
     description: |
-      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation
-      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message
-      Missing CNI relation or config
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation.
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".
   authn-webhook-endpoint:
     type: string
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -306,6 +306,13 @@ options:
 
       If unspecified, then the default CNI network is chosen alphabetically.
     default: ""
+  ignore-missing-cni:
+    type: boolean
+    default: false
+    description: |
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message
+      Missing CNI relation or config
   authn-webhook-endpoint:
     type: string
     default: ""

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -898,7 +898,7 @@ def set_final_status():
         if "cni" in goal_state.get("relations", {}):
             hookenv.status_set("waiting", "Waiting for CNI plugins to become available")
             return
-        elif not cni_config_exists():
+        elif not cni_config_exists() and (not hookenv.config("ignore-missing-cni")):
             hookenv.status_set("blocked", "Missing CNI relation or config")
             return
 

--- a/tests/unit/test_kubernetes_control_plane.py
+++ b/tests/unit/test_kubernetes_control_plane.py
@@ -583,3 +583,62 @@ class TestSendClusterDNSDetail:
         hookenv.goal_state.return_value = {}
         kubernetes_control_plane.send_cluster_dns_detail(self.kube_control)
         assert self.kube_control.set_dns.call_args == mock.call(None, None, None, False)
+
+    @mock.patch(
+        "reactive.kubernetes_control_plane.hookenv.config",
+        side_effect=[False, True, "10.152.183.0/24", False],
+    )
+    def test_ignore_missing_cni(self, mock_config):
+        """Test that set_final_status() will block appropriately according to the value of ignore-missing-cni config option"""
+        set_flag("certificates.available")
+        clear_flag("kubernetes-control-plane.secure-storage.failed")
+        set_flag("kube-control.connected")
+        set_flag("etcd.available")
+        set_flag("tls_client.certs.saved")
+        set_flag("kubernetes-control-plane.auth-webhook-service.started")
+        set_flag("kubernetes-control-plane.apiserver.configured")
+        set_flag("kubernetes-control-plane.apiserver.running")
+        set_flag("authentication.setup")
+        set_flag("kubernetes-control-plane.auth-webhook-tokens.setup")
+        set_flag("kubernetes-control-plane.components.started")
+        set_flag("cdk-addons.configured")
+        set_flag("kubernetes.cni-plugins.installed")
+        set_flag("kubernetes-control-plane.system-monitoring-rbac-role.applied")
+        set_flag("kube-api-endpoint.available")
+        db = unitdata.kv()
+        db.set(
+            "kubernetes-master.service-cidr", "10.152.183.0/24"
+        )  # Force the service cidr provided by the 3rd hookenv.config call to match
+        endpoint_from_name.return_value.has_response = True
+
+        clear_flag("cni.available")
+
+        # Test case when cni is not available but relation is present
+        hookenv.goal_state.return_value = {
+            "relations": {"loadbalancer-internal": None, "cni": None}
+        }
+        kubernetes_control_plane.set_final_status()
+        hookenv.status_set.assert_called_with(
+            "waiting",
+            "Waiting for CNI plugins to become available",
+        )
+
+        # Test case when cni is not available, relation is not present, cni_config does not exist, and ignore-missing-cni config option is False
+        # This uses the first hookenv.config side effect
+        kubernetes_common.cni_config_exists.return_value = False
+        hookenv.goal_state.return_value = {"relations": {"loadbalancer-internal": None}}
+        kubernetes_control_plane.set_final_status()
+        hookenv.status_set.assert_called_with(
+            "blocked",
+            "Missing CNI relation or config",
+        )
+
+        # Test case when cni is not available, relation is not present, cni_config does not exist, and ignore-missing-cni config option is True
+        # This uses the 2nd hookenv.call side effect, and the 3rd and 4th side effecs allow it to fall through to active status
+        # This should get us to active status since we provide values for the other 2 config checks that happen in the set_final_status method
+        # hookenv.config("service-cidr") followed by hookenv.config("enable-metrics")
+        kubernetes_control_plane.set_final_status()
+        hookenv.status_set.assert_called_with(
+            "active",
+            "Kubernetes control-plane running.",
+        )

--- a/tests/unit/test_kubernetes_control_plane.py
+++ b/tests/unit/test_kubernetes_control_plane.py
@@ -608,7 +608,8 @@ class TestSendClusterDNSDetail:
         db = unitdata.kv()
         db.set(
             # wokeignore:rule=master
-            "kubernetes-master.service-cidr", "10.152.183.0/24"
+            "kubernetes-master.service-cidr",
+            "10.152.183.0/24",
         )  # Force the service cidr provided by the 3rd hookenv.config call to match
         endpoint_from_name.return_value.has_response = True
 

--- a/tests/unit/test_kubernetes_control_plane.py
+++ b/tests/unit/test_kubernetes_control_plane.py
@@ -607,6 +607,7 @@ class TestSendClusterDNSDetail:
         set_flag("kube-api-endpoint.available")
         db = unitdata.kv()
         db.set(
+            # wokeignore:rule=master
             "kubernetes-master.service-cidr", "10.152.183.0/24"
         )  # Force the service cidr provided by the 3rd hookenv.config call to match
         endpoint_from_name.return_value.has_response = True


### PR DESCRIPTION
This PR adds a config option and associated unit tests to ignore a missing CNI and enter active status without it. This is holding up this [CAPI PR](https://github.com/charmed-kubernetes/cluster-api-provider-juju/pull/5) as the units are stuck in a blocked state without a CNI, however CAPI forbids installing one and believes it should be left to the user. 

Previous work was done in [this PR](https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/265) to make the subordinate optional, this just allows the user to not be met with a blocked status if they choose to via the ignore-missing-cni config option

Without specifying the ignore-missing-cni option, the user is met with the missing cni message:
```
kubernetes-control-plane  1.27.0-alpha.3  blocked      1  kubernetes-control-plane             0  yes      Missing CNI relation or config
```

When setting ignore-missing-cni to true, the control plane can go active idle:
```
kubernetes-control-plane  1.27.0-alpha.3  active       1  kubernetes-control-plane             0  yes      Kubernetes control-plane running.
```
Note that getting to this state requires setting dns-provider=none and enable-metrics=false as those pods cannot start with no CNI. 