### PR TITLE
1.27 kubernetes dropped support for aws cloud-provider

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
   lint-unit:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.9', '3.10', '3.11']"
     needs: 
       - call-inclusive-naming-check
 

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2396,8 +2396,11 @@ def configure_apiserver():
         if kube_version < (1, 27, 0):
             api_opts["cloud-provider"] = "aws"
         else:
-            # 1.27.0 drops aws cloud-provider, must use external provider
-            api_opts["cloud-provider"] = "external"
+            hookenv.log(
+                "AWS cloud-provider is no longer available in-tree. "
+                "the out-of-tree provider is necessary",
+                level="WARNING",
+            )
         if kube_version < (1, 25, 0):
             feature_gates.append("CSIMigrationAWS=false")
     elif is_state("endpoint.gcp.ready"):
@@ -2405,12 +2408,10 @@ def configure_apiserver():
         api_opts["cloud-config"] = str(api_cloud_config_path)
         if kube_version < (1, 25, 0):
             feature_gates.append("CSIMigrationGCE=false")
-    elif is_state("endpoint.vsphere.ready") and kube_version >= (
-        1,
-        12,
-    ):
-        api_opts["cloud-provider"] = "vsphere"
-        api_opts["cloud-config"] = str(api_cloud_config_path)
+    elif is_state("endpoint.vsphere.ready"):
+        if (1, 12) <= kube_version:
+            api_opts["cloud-provider"] = "vsphere"
+            api_opts["cloud-config"] = str(api_cloud_config_path)
         if kube_version < (1, 26, 0):
             feature_gates.append("CSIMigrationvSphere=false")
     elif is_state("endpoint.azure.ready"):
@@ -2582,8 +2583,11 @@ def configure_controller_manager():
         if kube_version < (1, 27, 0):
             controller_opts["cloud-provider"] = "aws"
         else:
-            # 1.27.0 drops aws cloud-provider, must use external provider
-            controller_opts["cloud-provider"] = "external"
+            hookenv.log(
+                "AWS cloud-provider is no longer available in-tree. "
+                "the out-of-tree provider is necessary",
+                level="WARNING",
+            )
         if kube_version < (1, 25, 0):
             feature_gates.append("CSIMigrationAWS=false")
     elif is_state("endpoint.gcp.ready"):
@@ -2591,12 +2595,10 @@ def configure_controller_manager():
         controller_opts["cloud-config"] = str(cm_cloud_config_path)
         if kube_version < (1, 25, 0):
             feature_gates.append("CSIMigrationGCE=false")
-    elif is_state("endpoint.vsphere.ready") and kube_version >= (
-        1,
-        12,
-    ):
-        controller_opts["cloud-provider"] = "vsphere"
-        controller_opts["cloud-config"] = str(cm_cloud_config_path)
+    elif is_state("endpoint.vsphere.ready"):
+        if (1, 12) <= kube_version:
+            controller_opts["cloud-provider"] = "vsphere"
+            controller_opts["cloud-config"] = str(cm_cloud_config_path)
         if kube_version < (1, 26, 0):
             feature_gates.append("CSIMigrationvSphere=false")
     elif is_state("endpoint.azure.ready"):

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2393,7 +2393,11 @@ def configure_apiserver():
     if has_external_cloud_provider():
         api_opts["cloud-provider"] = "external"
     elif is_state("endpoint.aws.ready"):
-        api_opts["cloud-provider"] = "aws"
+        if kube_version < (1, 27, 0):
+            api_opts["cloud-provider"] = "aws"
+        else:
+            # 1.27.0 drops aws cloud-provider, must use external provider
+            api_opts["cloud-provider"] = "external"
         if kube_version < (1, 25, 0):
             feature_gates.append("CSIMigrationAWS=false")
     elif is_state("endpoint.gcp.ready"):
@@ -2575,7 +2579,11 @@ def configure_controller_manager():
     if has_external_cloud_provider():
         controller_opts["cloud-provider"] = "external"
     elif is_state("endpoint.aws.ready"):
-        controller_opts["cloud-provider"] = "aws"
+        if kube_version < (1, 27, 0):
+            controller_opts["cloud-provider"] = "aws"
+        else:
+            # 1.27.0 drops aws cloud-provider, must use external provider
+            controller_opts["cloud-provider"] = "external"
         if kube_version < (1, 25, 0):
             feature_gates.append("CSIMigrationAWS=false")
     elif is_state("endpoint.gcp.ready"):

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2970,6 +2970,11 @@ def request_integration():
         )
         cloud.enable_object_storage_management(["kubernetes-*"])
         cloud.enable_load_balancer_management()
+
+        # Necessary for cloud-provider-aws
+        cloud.enable_autoscaling_readonly()
+        cloud.enable_instance_modification()
+        cloud.enable_region_readonly()
     elif is_state("endpoint.gcp.joined"):
         cloud = endpoint_from_flag("endpoint.gcp.joined")
         cloud.label_instance(

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -22,7 +22,6 @@ import socket
 import traceback
 import yaml
 
-from ipaddress import ip_network
 from itertools import filterfalse
 from shutil import move, copyfile
 from pathlib import Path
@@ -379,7 +378,6 @@ def check_for_upgrade_needed():
     remove_state("kubernetes-control-plane.default-cni.configured")
     remove_state("kubernetes-control-plane.sent-registry")
     remove_state("kubernetes-control-plane.ceph.permissions.requested")
-    remove_state("kubernetes-control-plane.shared-cluster-cidr")
 
     # Remove services from hacluster and leave to systemd while
     # hacluster is not ready to accept order and colocation constraints
@@ -3746,22 +3744,6 @@ def configure_default_cni():
     default_cni = hookenv.config("default-cni")
     kubernetes_common.configure_default_cni(default_cni)
     set_flag("kubernetes-control-plane.default-cni.configured")
-
-
-@when_any("cni.available", "kube-control.connected")
-@when_not("kubernetes-control-plane.shared-cluster-cidr")
-def share_cluster_cidr():
-    if not (cni_cluster_cidr := kubernetes_common.cluster_cidr()):
-        hookenv.log("cluster-cidr is not yet available", level="WARNING")
-        return
-    try:
-        cluster_cidr = ip_network(cni_cluster_cidr)
-    except ValueError as e:
-        hookenv.log(f"cluster-cidr ({cni_cluster_cidr}) is invalid: {e}", level="ERROR")
-    else:
-        kube_control = endpoint_from_flag("kube-control.connected")
-        kube_control.share_cluster_cidr(cluster_cidr)
-        set_flag("kubernetes-control-plane.shared-cluster-cidr")
 
 
 @when("ceph-client.available")


### PR DESCRIPTION
[LP#2013090](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2013090)

## Foreword
This PR implements configures kube-apiserver and kube-controller-manager arguments to remove the `cloud-provider=aws`. Also update the kube-control relation to share the cluster-cidr with other kube-control endpoints

## Changes
* if kubernetes version is `>= 1.27.0`, then enabling the `--cloud-provider=aws` will prevent the services from starting

## Requires
* https://github.com/juju-solutions/interface-kube-control/pull/39
* https://github.com/juju-solutions/interface-aws-integration/pull/15