### PR TITLE
reconfigure kubelet if our external cloud provider presence changes

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -3732,7 +3732,7 @@ def reconfigure_kubelet():
 @when("kubernetes-control-plane.kubelet.configured")
 def watch_xcp_for_changes():
     has_xcp = has_external_cloud_provider()
-    if data_changed("kubelet-has-xcp", has_xcp)
+    if data_changed("kubelet-has-xcp", has_xcp):
         hookenv.log("External cloud provider info has changed, will reconfigure Kubelet")
         clear_flag("kubernetes-control-plane.kubelet.configured")
 

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -3676,6 +3676,8 @@ def configure_kubelet():
         )
         return
     has_xcp = has_external_cloud_provider()
+    # keep track of xcp; we'll need to reconfigure kubelet if it changes later
+    data_changed("kubelet-has-xcp", has_xcp)
 
     local_endpoint = kubernetes_control_plane.get_local_api_endpoint()
     local_url = kubernetes_control_plane.get_api_url(local_endpoint)
@@ -3725,6 +3727,14 @@ def reconfigure_kubelet():
         hookenv.log("Removing file: " + cpu_manager_state)
         os.remove(cpu_manager_state)
     clear_flag("kubernetes-control-plane.kubelet.configured")
+
+
+@when("kubernetes-control-plane.kubelet.configured")
+def watch_xcp_for_changes():
+    has_xcp = has_external_cloud_provider()
+    if data_changed("kubelet-has-xcp", has_xcp)
+        hookenv.log("External cloud provider info has changed, will reconfigure Kubelet")
+        clear_flag("kubernetes-control-plane.kubelet.configured")
 
 
 @when("kubernetes-control-plane.kubelet.configured")

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -3733,7 +3733,9 @@ def reconfigure_kubelet():
 def watch_xcp_for_changes():
     has_xcp = has_external_cloud_provider()
     if data_changed("kubelet-has-xcp", has_xcp):
-        hookenv.log("External cloud provider info has changed, will reconfigure Kubelet")
+        hookenv.log(
+            "External cloud provider info has changed, will reconfigure Kubelet"
+        )
         clear_flag("kubernetes-control-plane.kubelet.configured")
 
 


### PR DESCRIPTION
We might configure the k-c-p kubelet before we know about an external cloud provider.  We should keep track of our xcp presence so we can reconfigure the kubelet when it changes.