### PR TITLE
add ignore pending pods config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -367,5 +367,6 @@ options:
     type: string
     default: ""
     description: |
-      Space separated list of pod names that will be ignored when checking for running pods in kube-system. The pod names in kube system are compared
-      against this list, and if a kube-system pod name starts with one of the names provided, it will be ignored during the check.
+      Space separated list of pod names in the kube-system namespace to ignore
+      when checking for running pods. Any non-Running Pod whose name is on
+      this list, will be ignored during the check.

--- a/config.yaml
+++ b/config.yaml
@@ -363,3 +363,9 @@ options:
   labels:
     # Override default from layer-kubernetes-node-base config.yaml
     default: "node-role.kubernetes.io/control-plane="
+  ignore-kube-system-pods:
+    type: string
+    default: ""
+    description: |
+      Space separated list of pod names that will be ignored when checking for running pods in kube-system. The pod names in kube system are compared
+      against this list, and if a kube-system pod name starts with one of the names provided, it will be ignored during the check.

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -243,11 +243,6 @@ register_trigger(
     when="cni.available", clear_flag="kubernetes-control-plane.components.started"
 )
 
-register_trigger(
-    when="endpoint.external-cloud-provider.joined",
-    clear_flag="kubernetes-control-plane.kubelet.configured",
-)
-
 
 def set_upgrade_needed(forced=False):
     set_state("kubernetes-control-plane.upgrade-needed")

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -2775,7 +2775,7 @@ def get_kube_system_pods_not_running():
 
     # Remove pods whose names start with ones provided in the ignore list
     pod_names_space_separated = hookenv.config("ignore-kube-system-pods")
-    ignore_list = pod_names_space_separated.split(" ")
+    ignore_list = pod_names_space_separated.strip().split()
     result["items"] = [
         pod
         for pod in result["items"]


### PR DESCRIPTION
This PR adds a config option that allows the user to specify pods to ignore during the check for pending kube-system pods. This is useful for CAPI as many pods are pending without a CNI deployed, which prevents the control plane from going active/idle. CoreDNS, for example, wont start without a CNI. 

The unit test for get_kube_system_pods_not_running was modified to test this new option. 

Additionally, the test_missing_cni was mistakenly placed under the TestSendClusterDNSDetail class on my previous PR. It was moved up with the rest of the tests, and mocks were added to account for the get_dns_provider and get_kube_system_pods_not_running calls since they contain some hookenv.config calls.