### PR TITLE
[LP#2015394] handle storage classes which have no listed annotations

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -1639,14 +1639,15 @@ def reconfigure_cdk_addons():
 def apply_default_storage(storage_class, def_storage_class):
     name = storage_class["metadata"]["name"]
     is_default = name == def_storage_class
-    new_annotations = storage_class["metadata"]["annotations"].copy()
+    cur_annotations = storage_class["metadata"].get("annotations") or {}
+    new_annotations = cur_annotations.copy()
     storage_class_annotation = "storageclass.kubernetes.io/is-default-class"
     if is_default:
         new_annotations.update(**{storage_class_annotation: "true"})
     elif not is_default and storage_class_annotation in new_annotations:
         new_annotations.pop(storage_class_annotation)
 
-    if new_annotations != storage_class["metadata"]["annotations"]:
+    if new_annotations != cur_annotations:
         hookenv.log(
             f"{'S' if is_default else 'Uns'}etting default storage-class {name}.",
             hookenv.INFO,


### PR DESCRIPTION
[LP#2015394](https://launchpad.net/bugs/2015394)
Handle the condition where a storage class doesn't have any `annotations`

```
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/.venv/lib/python3.10/site-packages/charms/reactive/__init__.py", line 74, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/.venv/lib/python3.10/site-packages/charms/reactive/bus.py", line 390, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/.venv/lib/python3.10/site-packages/charms/reactive/bus.py", line 359, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/.venv/lib/python3.10/site-packages/charms/reactive/bus.py", line 181, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/charm/reactive/kubernetes_control_plane.py", line 1708, in configure_cdk_addons
    default_storage = configure_default_storage_class()
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/charm/reactive/kubernetes_control_plane.py", line 1675, in configure_default_storage_class
    apply_default_storage(storage_class, def_storage_class)
  File "/var/lib/juju/agents/unit-kubernetes-control-plane-0/charm/reactive/kubernetes_control_plane.py", line 1642, in apply_default_storage
    new_annotations = storage_class["metadata"]["annotations"].copy()
KeyError: 'annotations'
```