### PR TITLE
 [LP#1949913] Use a layer configurable option to change the secrets backend index

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -44,6 +44,8 @@ options:
       - snap.kube-proxy.daemon
   hacluster:
     binding_address: 'kube-api-endpoint'
+  vault-kv:
+    secrets-backend-format: "charm-{model-uuid}-{app}"
 exclude:
   - .tox
   - __pycache__

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -21,3 +21,8 @@ psutil==5.9.2
 
 # avoid ops 2.1.0 which had a broken setup that kills pip
 ops!=2.1.0
+
+# attrs>=23.1.0, urllib3<=2.0.0 has a build dependency on hatchling, calver, et al
+# rather than pulling in a list of new deps, pin attrs
+attrs<23.1.0
+urllib3<2.0.0

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -22,7 +22,7 @@ psutil==5.9.2
 # avoid ops 2.1.0 which had a broken setup that kills pip
 ops!=2.1.0
 
-# attrs>=23.1.0, urllib3<=2.0.0 has a build dependency on hatchling, calver, et al
-# rather than pulling in a list of new deps, pin attrs
+# attrs>=23.1.0, urllib3<=2.0.0 have a build dependency on hatchling, calver, et al
+# rather than pulling in a list of new deps, pin these
 attrs<23.1.0
 urllib3<2.0.0


### PR DESCRIPTION
Upgrades of the Kubernetes-Control-Plane charm allows for layer-vault-kv to disambiguate from other k8s-cp related to vault in a cross-model relation style

* set `secrets-backend-format` to use the model-uuid in the secrets backend
* testing upgrades

Associated with 
* https://github.com/openstack-charmers/charm-interface-vault-kv/pull/14
* https://github.com/juju-solutions/layer-vault-kv/pull/20