### PR TITLE
Update renamed metrics to fix grafana dashboard. Fixes: LP#1956611

### DIFF
--- a/templates/grafana/autoload/kubernetes.json
+++ b/templates/grafana/autoload/kubernetes.json
@@ -904,7 +904,7 @@
                         ],
                         "timeFrom":null,
                         "timeShift":null,
-                        "title":"kubernetes-master CPU idle",
+                        "title":"kubernetes-control-plane CPU idle",
                         "tooltip":{
                             "shared":true,
                             "sort":0,
@@ -945,7 +945,7 @@
                     }
                 ],
                 "repeat":null,
-                "title":"kubernetes-master CPU idle",
+                "title":"kubernetes-control-plane CPU idle",
                 "type":"row"
             },
             {
@@ -1111,7 +1111,7 @@
                         "steppedLine":false,
                         "targets":[
                             {
-                                "expr":"sum(rate(apiserver_request_latencies_sum{}[1m])) / sum(rate(apiserver_request_latencies_count{}[1m]))",
+                                "expr":"sum(rate(apiserver_request_duration_seconds_sum{}[1m])) / sum(rate(apiserver_request_duration_seconds_count{}[1m]))",
                                 "format":"time_series",
                                 "intervalFactor":2,
                                 "legendFormat":"{{username}}",
@@ -1206,7 +1206,7 @@
                         "steppedLine":false,
                         "targets":[
                             {
-                                "expr":"sum(rate(apiserver_request_count{}[1m])) by (code)",
+                                "expr":"sum(rate(apiserver_request_total{}[1m])) by (code)",
                                 "format":"time_series",
                                 "intervalFactor":2,
                                 "legendFormat":"{{code}}",
@@ -1396,7 +1396,7 @@
                         "steppedLine":false,
                         "targets":[
                             {
-                                "expr":"histogram_quantile(0.95, sum(rate(apiserver_request_latencies_bucket{}[5m])) by (le,resource) )",
+                                "expr":"histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{}[5m])) by (le,resource) )",
                                 "format":"time_series",
                                 "hide":false,
                                 "intervalFactor":2,
@@ -1492,7 +1492,7 @@
                         "steppedLine":false,
                         "targets":[
                             {
-                                "expr":"histogram_quantile(0.95, sum(rate(apiserver_request_latencies_bucket{}[5m])) by (le,verb) )",
+                                "expr":"histogram_quantile(0.95, sum(rate(apiserver_request_duration_seconds_bucket{}[5m])) by (le,verb) )",
                                 "format":"time_series",
                                 "hide":false,
                                 "intervalFactor":2,
@@ -1506,7 +1506,7 @@
                         ],
                         "timeFrom":null,
                         "timeShift":null,
-                        "title":"API request latency by resource 95th percentile",
+                        "title":"API request latency by request method 95th percentile",
                         "tooltip":{
                             "shared":true,
                             "sort":0,
@@ -1603,10 +1603,10 @@
                         "steppedLine":false,
                         "targets":[
                             {
-                                "expr":"rate(admission_quota_controller_adds{}[10m])",
+                                "expr":"rate(workqueue_adds_total{}[10m])",
                                 "format":"time_series",
                                 "intervalFactor":2,
-                                "legendFormat":"",
+                                "legendFormat":"{{ name }}",
                                 "refId":"A",
                                 "step":60
                             }
@@ -1694,10 +1694,10 @@
                         "steppedLine":false,
                         "targets":[
                             {
-                                "expr":"rate(admission_quota_controller_queue_latency_sum{}[10m]) / rate(admission_quota_controller_queue_latency_count{}[10m])",
+                                "expr":"rate(workqueue_queue_duration_seconds_sum{}[10m]) / rate(workqueue_queue_duration_seconds_count{}[10m])",
                                 "format":"time_series",
                                 "intervalFactor":2,
-                                "legendFormat":"",
+                                "legendFormat":"{{ name }}",
                                 "refId":"A",
                                 "step":60
                             }
@@ -1785,10 +1785,10 @@
                         "steppedLine":false,
                         "targets":[
                             {
-                                "expr":"rate(admission_quota_controller_work_duration_sum{}[10m]) / rate(admission_quota_controller_work_duration_count{}[10m])",
+                                "expr":"rate(workqueue_work_duration_seconds_sum{}[10m]) / rate(workqueue_work_duration_seconds_count{}[10m])",
                                 "format":"time_series",
                                 "intervalFactor":2,
-                                "legendFormat":"",
+                                "legendFormat":"{{ name }}",
                                 "refId":"A",
                                 "step":60
                             }
@@ -1859,7 +1859,7 @@
                         "fill":1,
                         "gridPos":{
                             "h":7,
-                            "w":12,
+                            "w":24,
                             "x":0,
                             "y":13
                         },
@@ -1892,204 +1892,22 @@
                         "steppedLine":false,
                         "targets":[
                             {
-                                "expr":"etcd_request_cache_get_latencies_summary{}",
-                                "format":"time_series",
-                                "intervalFactor":2,
-                                "legendFormat":"Quantile {{quantile}}",
-                                "refId":"A",
-                                "step":60
-                            }
-                        ],
-                        "thresholds":[
-
-                        ],
-                        "timeFrom":null,
-                        "timeShift":null,
-                        "title":"Cache request latencies (get)",
-                        "tooltip":{
-                            "shared":true,
-                            "sort":0,
-                            "value_type":"individual"
-                        },
-                        "type":"graph",
-                        "xaxis":{
-                            "buckets":null,
-                            "mode":"time",
-                            "name":null,
-                            "show":true,
-                            "values":[
-
-                            ]
-                        },
-                        "yaxes":[
-                            {
-                                "format":"ms",
-                                "label":null,
-                                "logBase":1,
-                                "max":null,
-                                "min":"0",
-                                "show":true
+                                "expr": "histogram_quantile(0.95, sum(rate(etcd_request_duration_seconds_bucket[5m])) by (le))",
+                                "interval": "",
+                                "legendFormat": "p95",
+                                "refId": "A"
                             },
                             {
-                                "format":"short",
-                                "label":null,
-                                "logBase":1,
-                                "max":null,
-                                "min":null,
-                                "show":false
-                            }
-                        ],
-                        "yaxis":{
-                            "align":false,
-                            "alignLevel":null
-                        }
-                    },
-                    {
-                        "aliasColors":{
-
-                        },
-                        "bars":false,
-                        "dashLength":10,
-                        "dashes":false,
-                        "datasource":"prometheus - Juju generated source",
-                        "fill":1,
-                        "gridPos":{
-                            "h":7,
-                            "w":12,
-                            "x":12,
-                            "y":13
-                        },
-                        "id":35,
-                        "legend":{
-                            "alignAsTable":true,
-                            "avg":true,
-                            "current":true,
-                            "max":true,
-                            "min":true,
-                            "show":true,
-                            "total":false,
-                            "values":true
-                        },
-                        "lines":true,
-                        "linewidth":1,
-                        "links":[
-
-                        ],
-                        "nullPointMode":"null",
-                        "percentage":false,
-                        "pointradius":5,
-                        "points":false,
-                        "renderer":"flot",
-                        "seriesOverrides":[
-
-                        ],
-                        "spaceLength":10,
-                        "stack":false,
-                        "steppedLine":false,
-                        "targets":[
-                            {
-                                "expr":"etcd_request_cache_add_latencies_summary{}",
-                                "format":"time_series",
-                                "intervalFactor":2,
-                                "legendFormat":"Quantile {{quantile}}",
-                                "refId":"A",
-                                "step":60
-                            }
-                        ],
-                        "thresholds":[
-
-                        ],
-                        "timeFrom":null,
-                        "timeShift":null,
-                        "title":"Cache request latencies (add)",
-                        "tooltip":{
-                            "shared":true,
-                            "sort":0,
-                            "value_type":"individual"
-                        },
-                        "type":"graph",
-                        "xaxis":{
-                            "buckets":null,
-                            "mode":"time",
-                            "name":null,
-                            "show":true,
-                            "values":[
-
-                            ]
-                        },
-                        "yaxes":[
-                            {
-                                "format":"ms",
-                                "label":null,
-                                "logBase":1,
-                                "max":null,
-                                "min":"0",
-                                "show":true
+                                "expr": "histogram_quantile(0.90, sum(rate(etcd_request_duration_seconds_bucket[5m])) by (le))",
+                                "interval": "",
+                                "legendFormat": "p90",
+                                "refId": "B"
                             },
                             {
-                                "format":"short",
-                                "label":null,
-                                "logBase":1,
-                                "max":null,
-                                "min":null,
-                                "show":false
-                            }
-                        ],
-                        "yaxis":{
-                            "align":false,
-                            "alignLevel":null
-                        }
-                    },
-                    {
-                        "aliasColors":{
-
-                        },
-                        "bars":false,
-                        "dashLength":10,
-                        "dashes":false,
-                        "datasource":"prometheus - Juju generated source",
-                        "fill":1,
-                        "gridPos":{
-                            "h":7,
-                            "w":12,
-                            "x":0,
-                            "y":20
-                        },
-                        "id":33,
-                        "legend":{
-                            "alignAsTable":true,
-                            "avg":true,
-                            "current":true,
-                            "max":true,
-                            "min":true,
-                            "show":true,
-                            "total":false,
-                            "values":true
-                        },
-                        "lines":true,
-                        "linewidth":1,
-                        "links":[
-
-                        ],
-                        "nullPointMode":"null",
-                        "percentage":false,
-                        "pointradius":5,
-                        "points":false,
-                        "renderer":"flot",
-                        "seriesOverrides":[
-
-                        ],
-                        "spaceLength":10,
-                        "stack":false,
-                        "steppedLine":false,
-                        "targets":[
-                            {
-                                "expr":"etcd_helper_cache_hit_count{} / (etcd_helper_cache_miss_count{} + etcd_helper_cache_hit_count{}) * 100",
-                                "format":"time_series",
-                                "intervalFactor":2,
-                                "legendFormat":"Hit ratio",
-                                "refId":"A",
-                                "step":60
+                                "expr": "histogram_quantile(0.5, sum(rate(etcd_request_duration_seconds_bucket[5m])) by (le))",
+                                "interval": "",
+                                "legendFormat": "p50",
+                                "refId": "C"
                             }
                         ],
                         "thresholds":[
@@ -2097,103 +1915,7 @@
                         ],
                         "timeFrom":null,
                         "timeShift":null,
-                        "title":"Cache hit ratio",
-                        "tooltip":{
-                            "shared":true,
-                            "sort":0,
-                            "value_type":"individual"
-                        },
-                        "type":"graph",
-                        "xaxis":{
-                            "buckets":null,
-                            "mode":"time",
-                            "name":null,
-                            "show":true,
-                            "values":[
-
-                            ]
-                        },
-                        "yaxes":[
-                            {
-                                "format":"percent",
-                                "label":null,
-                                "logBase":1,
-                                "max":"100",
-                                "min":"0",
-                                "show":true
-                            },
-                            {
-                                "format":"short",
-                                "label":null,
-                                "logBase":1,
-                                "max":null,
-                                "min":null,
-                                "show":false
-                            }
-                        ],
-                        "yaxis":{
-                            "align":false,
-                            "alignLevel":null
-                        }
-                    },
-                    {
-                        "aliasColors":{
-
-                        },
-                        "bars":false,
-                        "dashLength":10,
-                        "dashes":false,
-                        "datasource":"prometheus - Juju generated source",
-                        "fill":1,
-                        "gridPos":{
-                            "h":7,
-                            "w":12,
-                            "x":12,
-                            "y":20
-                        },
-                        "id":34,
-                        "legend":{
-                            "alignAsTable":true,
-                            "avg":true,
-                            "current":true,
-                            "max":true,
-                            "min":true,
-                            "show":true,
-                            "total":false,
-                            "values":true
-                        },
-                        "lines":true,
-                        "linewidth":1,
-                        "links":[
-
-                        ],
-                        "nullPointMode":"null",
-                        "percentage":false,
-                        "pointradius":5,
-                        "points":false,
-                        "renderer":"flot",
-                        "seriesOverrides":[
-
-                        ],
-                        "spaceLength":10,
-                        "stack":false,
-                        "steppedLine":false,
-                        "targets":[
-                            {
-                                "expr":"sum(rate(etcd_request_latencies_summary_sum{}[1m])) by (operation) / sum(rate(etcd_request_latencies_summary_count{}[1m])) by (operation)",
-                                "format":"time_series",
-                                "intervalFactor":2,
-                                "legendFormat":"{{operation}}",
-                                "refId":"A",
-                                "step":60
-                            }
-                        ],
-                        "thresholds":[
-
-                        ],
-                        "timeFrom":null,
-                        "timeShift":null,
-                        "title":"Average cache request latencies",
+                        "title":"Etcd request latencies",
                         "tooltip":{
                             "shared":true,
                             "sort":0,


### PR DESCRIPTION
[LP#1956611](https://bugs.launchpad.net/charm-kubernetes-master/+bug/1956611) grafana dashboard metrics have either been renamed or gone missing since this template was created. 

This PR seems to fix the naming convention without any specific tests to confirm they won't change again in the future. 

[1] https://github.com/kubernetes/kubernetes/pull/71300/files
[2] https://github.com/kubernetes/kubernetes/pull/74418/files#diff-5a0d6b0e34ff7529a142eec3648065b523e9c69fba321eefd7eed5636b27ecd9L45-R45
