### PR TITLE
Add cinder-availability-zone config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -374,3 +374,9 @@ options:
       Space separated list of pod names in the kube-system namespace to ignore
       when checking for running pods. Any non-Running Pod whose name is on
       this list, will be ignored during the check.
+  cinder-availability-zone:
+    type: string
+    default: ""
+    description: |
+      Availability zone to use with Cinder CSI. This is passed through to the
+      parameters.availability field of the cdk-cinder StorageClass.

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -1783,6 +1783,7 @@ def configure_cdk_addons():
         "ceph-kubernetes-key=" + (ceph.get("admin_key", "")),
         'ceph-mon-hosts="' + (ceph.get("mon_hosts", "")) + '"',
         "ceph-user=" + hookenv.application_name(),
+        "cinder-availability-zone=" + hookenv.config("cinder-availability-zone"),
         "default-storage=" + default_storage,
         "enable-keystone=" + keystoneEnabled,
         "keystone-cert-file=" + keystone.get("cert", ""),


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/1972861

This needs to be configurable in situations where Nova and Cinder have separate AZs.