### PR TITLE
Generating openstack cloud config requires at least one relation endpoint

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -1797,7 +1797,7 @@ def configure_cdk_addons():
         "enable-openstack=" + enable_openstack,
         "cluster-tag=" + cluster_tag,
     ]
-    if openstack:
+    if openstack and openstack.relations:
         args.extend(
             [
                 "openstack-cloud-conf="


### PR DESCRIPTION
When removing the `opentstack` endpoint from `kubernetes-control-plane`, the `relation-departed` hook fires before `relation-broken` hook.  

When running the `relation-departed` hook on the last endpoint -- the relation still exists, but there are no joined units.  It then becomes impossible to `generate_openstack_cloud_config` and the charm goes into `Error` state

Adding this simple check ensures there is at least one endpoint in the relation