### PR TITLE
add cnis that require privileged containers to the auto list

### DIFF
--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -1967,7 +1967,7 @@ def _any_priviledged_cni() -> bool:
         return False
     require_priv = {"calico", "kube-ovn", "cilium"}
     cni_conf_files = {
-        config.get("cni-conf-file") for config in cni.get_configs().values()
+        config.get("cni-conf-file", "") for config in cni.get_configs().values()
     }
     return any(app in fname for fname in cni_conf_files for app in require_priv)
 

--- a/tests/unit/test_kubernetes_control_plane.py
+++ b/tests/unit/test_kubernetes_control_plane.py
@@ -114,6 +114,7 @@ def update_for_service_cidr_expansion():
 def test_cni_privileges(cni_conf_file, privileged):
     cni = endpoint_from_name.return_value = mock.MagicMock()
     cni.get_configs.return_value = {
+        "no-cni-config": {},
         "my-cni": {"cni-conf-file": cni_conf_file},
         "other-cni": {"cni-conf-file": "01-cni.conflist"},
     }


### PR DESCRIPTION
calico, cilium, and kube-ovn in 1.28 will require that the api server permit privileged containers

Let's add these to the auto list so we have seemless upgrades to 1.28 without requiring users to set the `allow-privileged` flag on the control plane charm


we can discover which cnis are connected using the cni-conf-file provided in the [cni relation](https://github.com/juju-solutions/interface-kubernetes-cni/blob/master/provides.py#L56-L76)
