### PR TITLE
Handle certificates relation

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -23,7 +23,7 @@ jobs:
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
           bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763"
       - name: Run test
-        run: tox -e integration
+        run: tox -e integration -- --basetemp=/home/ubuntu/pytest
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp

--- a/config.yaml
+++ b/config.yaml
@@ -4,3 +4,20 @@ options:
     default: "1.27/edge"
     description: |
       Snap channel to install Kubernetes control plane services from
+  dns_domain:
+    type: string
+    default: cluster.local
+    description: The local domain for cluster dns
+  extra_sans:
+    type: string
+    default: ""
+    description: |
+      Space-separated list of extra SAN entries to add to the x509 certificate
+      created for the control plane nodes.
+  service-cidr:
+    type: string
+    default: 10.152.183.0/24
+    description: |
+      CIDR to use for Kubernetes services. After deployment it is
+      only possible to increase the size of the IP range. It is not possible to
+      change or shrink the address range after deployment.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,3 +20,10 @@ description: |
   A third paragraph that explains what need the charm meets.
 
   Finally, a paragraph that describes whom the charm is useful for.
+
+provides:
+  kube-control:
+    interface: kube-control
+requires:
+  certificates:
+    interface: tls-certificates

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
+# FIXME
+#charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@gkk/certs
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 ops >= 2.2.0
+ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
+pydantic < 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
-# FIXME
-#charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@gkk/certs
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 ops >= 2.2.0
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,10 +5,14 @@
 """Charm."""
 
 import logging
+import socket
 
+import charms.contextual_status as status
 import ops
 from charms import kubernetes_snaps
 from charms.reconciler import Reconciler
+from ops import BlockedStatus, WaitingStatus
+from ops.interface_tls_certificates import CertificatesRequires
 
 log = logging.getLogger(__name__)
 
@@ -18,11 +22,76 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.certificates = CertificatesRequires(self, endpoint="certificates")
         self.reconciler = Reconciler(self, self.reconcile)
 
     def reconcile(self, event):
         """Reconcile state change events."""
         kubernetes_snaps.install(channel=self.model.config["channel"], control_plane=True)
+        self.request_certificates()
+        self.write_certificates()
+
+    def request_certificates(self):
+        """Request client and server certificates."""
+        if not self.certificates.relation:
+            status.add(BlockedStatus("Missing relation to certificate authority"))
+            return
+
+        bind_addrs = kubernetes_snaps.get_bind_addresses()
+        common_name = kubernetes_snaps.get_public_address()
+        domain = self.config["dns_domain"]
+        extra_sans = self.config["extra_sans"].split()
+        k8s_service_addrs = kubernetes_snaps.get_kubernetes_service_addresses(
+            self.config["service-cidr"].split(",")
+        )
+        ingress_addrs = [
+            # RFC 5280 section 4.2.1.6: "For IP version 6 ... the octet string
+            # MUST contain exactly sixteen octets." We'll use .exploded to be
+            # safe.
+            addr.exploded
+            for addr in self.model.get_binding("kube-control").network.ingress_addresses
+        ]
+
+        sans = [
+            # The CN field is checked as a hostname, so if it's an IP, it
+            # won't match unless also included in the SANs as an IP field.
+            common_name,
+            "127.0.0.1",
+            socket.gethostname(),
+            socket.getfqdn(),
+            "kubernetes",
+            f"kubernetes.{domain}",
+            "kubernetes.default",
+            "kubernetes.default.svc",
+            f"kubernetes.default.svc.{domain}",
+        ]
+        sans += bind_addrs
+        sans += ingress_addrs
+        sans += k8s_service_addrs
+        sans += extra_sans
+        sans = list(set(sans))
+
+        self.certificates.request_client_cert("system:kube-apiserver")
+        self.certificates.request_server_cert(cn=common_name, sans=sans)
+
+    def write_certificates(self):
+        """Write certificates from the certificates relation."""
+        common_name = kubernetes_snaps.get_public_address()
+        ca = self.certificates.ca
+        client_cert = self.certificates.client_certs_map.get("system:kube-apiserver")
+        server_cert = self.certificates.server_certs_map.get(common_name)
+
+        if not ca or not client_cert or not server_cert:
+            status.add(WaitingStatus("Waiting for certificates"))
+            return
+
+        kubernetes_snaps.write_certificates(
+            ca=ca,
+            client_cert=client_cert.cert,
+            client_key=client_cert.key,
+            server_cert=server_cert.cert,
+            server_key=server_cert.key,
+        )
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/tests/data/overlay.yaml
+++ b/tests/data/overlay.yaml
@@ -1,0 +1,13 @@
+applications:
+  kubernetes-control-plane:
+    charm: {{charm}}
+    channel: null
+  # Remove the apps we don't support yet
+  etcd: null
+  calico: null
+  containerd: null
+  kubernetes-worker: null
+# override machines since we dropped kubernetes-worker
+machines:
+  "0":
+    constraints: "cores=2 mem=8G root-disk=16G"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -2,33 +2,29 @@
 # Copyright 2023 Canonical
 # See LICENSE file for licensing details.
 
-import asyncio
 import logging
-from pathlib import Path
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
 
-logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
+log = logging.getLogger(__name__)
 
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
-    """Build the charm-under-test and deploy it together with related charms.
-
-    Assert on the unit status before any relations/configurations take place.
-    """
-    # Build and deploy charm from local source folder
+    """Build kubernetes-control-plane and deploy with kubernetes-core bundle."""
+    log.info("Building charm")
     charm = await ops_test.build_charm(".")
 
-    # Deploy the charm and wait for active/idle status
-    await asyncio.gather(
-        ops_test.model.deploy(charm, application_name=APP_NAME),
-        ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
-        ),
+    bundle, *overlays = await ops_test.async_render_bundles(
+        ops_test.Bundle("kubernetes-core", channel="edge"), "tests/data/overlay.yaml", charm=charm
     )
+
+    log.info("Deploying bundle")
+    cmd = ["juju", "deploy", "-m", ops_test.model_full_name, bundle]
+    for overlay in overlays:
+        cmd += ["--overlay", overlay]
+    rc, stdout, stderr = await ops_test.run(*cmd)
+    assert rc == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
+
+    await ops_test.model.wait_for_idle(status="active", timeout=60 * 60)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,22 +3,83 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
-import unittest
+import json
 from unittest.mock import patch
 
 import ops
 import ops.testing
+import pytest
 from charm import KubernetesControlPlaneCharm
+from ops import ActiveStatus, BlockedStatus, WaitingStatus
 
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.harness = ops.testing.Harness(KubernetesControlPlaneCharm)
-        self.addCleanup(self.harness.cleanup)
+@pytest.fixture
+def harness():
+    harness = ops.testing.Harness(KubernetesControlPlaneCharm)
+    try:
+        harness.add_network("10.0.0.10", endpoint="kube-control")
+        yield harness
+    finally:
+        harness.cleanup()
 
-    @patch("charms.kubernetes_snaps.install")
-    def test_start(self, kubernetes_snaps_install):
-        self.harness.begin_with_initial_hooks()
 
-        kubernetes_snaps_install.assert_called()
-        self.assertEqual(self.harness.model.unit.status, ops.ActiveStatus())
+@patch("charms.kubernetes_snaps.get_public_address")
+@patch("charms.kubernetes_snaps.install")
+def test_missing_certificate_authority(snaps_install, get_public_address, harness):
+    get_public_address.return_value = "10.0.0.10"
+
+    harness.begin_with_initial_hooks()
+
+    assert snaps_install.called
+    assert harness.model.unit.status == BlockedStatus("Missing relation to certificate authority")
+
+
+@patch("charms.kubernetes_snaps.get_public_address")
+@patch("charms.kubernetes_snaps.install")
+def test_waiting_for_certificates(kubernetes_snaps_install, get_public_address, harness):
+    get_public_address.return_value = "10.0.0.10"
+    certificates_relation_id = harness.add_relation("certificates", "easyrsa")
+
+    harness.begin()
+    harness.add_relation_unit(certificates_relation_id, "easyrsa/0")
+
+    assert harness.model.unit.status == WaitingStatus("Waiting for certificates")
+
+
+@patch("charms.kubernetes_snaps.write_certificates")
+@patch("charms.kubernetes_snaps.get_public_address")
+@patch("charms.kubernetes_snaps.install")
+def test_active(kubernetes_snaps_install, get_public_address, write_certificates, harness):
+    get_public_address.return_value = "10.0.0.10"
+    certificates_relation_id = harness.add_relation("certificates", "easyrsa")
+    harness.add_relation_unit(certificates_relation_id, "easyrsa/0")
+
+    harness.begin()
+    harness.update_relation_data(
+        certificates_relation_id,
+        "easyrsa/0",
+        {
+            "ca": "test-ca",
+            "client.cert": "test-client-cert-default",
+            "client.key": "test-client-key-default",
+            "kubernetes-control-plane_0.server.key": "test-server-key",
+            "kubernetes-control-plane_0.server.cert": "test-server-cert",
+            "kubernetes-control-plane_0.processed_client_requests": json.dumps(
+                {
+                    "system:kube-apiserver": {
+                        "cert": "test-client-cert-apiserver",
+                        "key": "test-client-key-apiserver",
+                    }
+                }
+            ),
+        },
+    )
+
+    assert write_certificates.called_once_with(
+        ca="test-ca",
+        client_cert="test-client-cert-apiserver",
+        client_key="test-client-key-apiserver",
+        server_cert="test-server-cert",
+        server_key="test-server-key",
+    )
+    assert harness.model.unit.status == ActiveStatus()


### PR DESCRIPTION
Depends on https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps/pull/2

This adds the necessary bits to relate to easyrsa/vault, request client and server certificates, and to write those certificates to disk.