### PR TITLE
1.28 release prep

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.27/edge"
+    default: "1.28/stable"
     description: |
       Snap channel to install Kubernetes control plane services from
   client_password:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,7 +44,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="module")
 def k8s_core_bundle(ops_test):
-    return ops_test.Bundle("kubernetes-core", channel="edge")
+    return ops_test.Bundle("kubernetes-core", channel="1.28/stable")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Per [release checklist](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#pin-snap-channel-on-bundlescharms-in-the-release-branches)