### PR TITLE
drop pesky bionic pinnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt update
           sudo apt install python3-virtualenv -y
           sudo snap install docker --channel=stable
-          sudo snap install charm --channel=2.x/stable --classic
+          sudo snap install charm --channel=3.x/stable --classic
 
       - name: Build Charm
         run:  charm build . -F

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,9 +62,6 @@ jobs:
     timeout-minutes: 360
     needs:
       - build-dependencies
-    strategy:
-      matrix:
-        juju: ['2.9', '3.0']
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -72,13 +69,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
-          juju-channel: ${{ matrix.juju }}/stable
+          juju-channel: 3.1/stable
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"

--- a/build-cni-resources.sh
+++ b/build-cni-resources.sh
@@ -5,7 +5,7 @@ set -eux
 # When changing CNI_VERSION, it should be updated in both
 # charm-kubernetes-control-plane/build-cni-resources.sh and
 # charm-kubernetes-worker/build-cni-resources.sh
-CNI_VERSION="${CNI_VERSION:-v0.7.5}"
+CNI_VERSION="${CNI_VERSION:-v1.2.0}"
 ARCH="${ARCH:-amd64 arm64 s390x}"
 
 build_script_commit="$(git show --oneline -q)"
@@ -29,8 +29,8 @@ mkdir "$temp_dir"
       -e GOOS=linux \
       -e GOARCH="$arch" \
       -v "$temp_dir"/cni-plugins:/cni \
-      golang:1.15 \
-      /bin/bash -c "cd /cni && ./build.sh && chown -R ${USER_ID}:${GROUP_ID} /cni"
+      golang:1.17 \
+      /bin/bash -c "cd /cni && ./build_linux.sh && chown -R ${USER_ID}:${GROUP_ID} /cni"
 
     (cd cni-plugins/bin
       echo "cni-$arch $CNI_VERSION" >> BUILD_INFO

--- a/config.yaml
+++ b/config.yaml
@@ -105,7 +105,7 @@ options:
       will not be loaded.
   channel:
     type: string
-    default: "1.27/edge"
+    default: "1.28/edge"
     description: |
       Snap channel to install Kubernetes control plane services from
   client_password:

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -1960,6 +1960,18 @@ def remove_nrpe_config():
     remove_state("nrpe-external-master.initial-config")
 
 
+def _any_priviledged_cni() -> bool:
+    """Returns boolean indicating relation to a cni requiring priviledge."""
+    cni = endpoint_from_name("cni")
+    if not cni:
+        return False
+    require_priv = {"calico", "kube-ovn", "cilium"}
+    cni_conf_files = {
+        config.get("cni-conf-file", "") for config in cni.get_configs().values()
+    }
+    return any(app in fname for fname in cni_conf_files for app in require_priv)
+
+
 def is_privileged():
     """Return boolean indicating whether or not to set allow-privileged=true."""
     privileged = hookenv.config("allow-privileged").lower()
@@ -1968,6 +1980,7 @@ def is_privileged():
             is_state("kubernetes-control-plane.gpu.enabled")
             or is_state("ceph-client.available")
             or is_state("endpoint.openstack.joined")
+            or _any_priviledged_cni()
         )
     else:
         return privileged == "true"

--- a/tests/unit/test_kubernetes_control_plane.py
+++ b/tests/unit/test_kubernetes_control_plane.py
@@ -15,7 +15,7 @@ from charms.layer.kubernetes_common import (
     kubectl_manifest,
 )
 from charms.reactive import endpoint_from_flag, endpoint_from_name, set_state
-from charms.reactive import set_flag, is_flag_set, clear_flag
+from charms.reactive import set_flag, is_flag_set, clear_flag, is_state
 from charmhelpers.core import hookenv, host, unitdata
 
 
@@ -100,6 +100,27 @@ def update_for_service_cidr_expansion():
     ]
     assert kubectl.call_count == 0
     kubernetes_control_plane.update_for_service_cidr_expansion()
+
+
+@pytest.mark.parametrize(
+    "cni_conf_file, privileged",
+    [
+        ("10-flannel.conflist", False),
+        ("10-calico.conflist", True),
+        ("05-cilium.conflist", True),
+        ("01-kube-ovn.conflist", True),
+    ],
+)
+def test_cni_privileges(cni_conf_file, privileged):
+    cni = endpoint_from_name.return_value = mock.MagicMock()
+    cni.get_configs.return_value = {
+        "no-cni-config": {},
+        "my-cni": {"cni-conf-file": cni_conf_file},
+        "other-cni": {"cni-conf-file": "01-cni.conflist"},
+    }
+    hookenv.config.return_value = "auto"
+    is_state.return_value = False
+    assert kubernetes_control_plane.is_privileged() == privileged
 
 
 def test_service_cidr_greenfield_deploy():

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     aiohttp
     ipdb
     lightkube
-    juju < 3.1
+    juju
 commands = 
     pytest --tb native \
            --asyncio-mode=auto \

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -6,21 +6,7 @@ git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
 
 # idna>=3.4 and beyond (needed by aiohttp and hvac)
 # requires flit-core for building its wheel.
-# 
-# flit-core can run on python3.6, but requires pip 
-# be upgraded to at least 20.0.2 (same as on focal)
-#
 flit-core<4
-pip==20.0.2  # necessary for bionic
-
-# psutil>=5.9.3 added requirement of setuptools>=43
-# 
-# layer-basic pins-back pip and setuptools
-# for full compatability with bionic
-psutil==5.9.2
-
-# avoid ops 2.1.0 which had a broken setup that kills pip
-ops!=2.1.0
 
 # attrs>=23.1.0, urllib3<=2.0.0 have a build dependency on hatchling, calver, et al
 # rather than pulling in a list of new deps, pin these


### PR DESCRIPTION
Support for bionic has been dropped since 1.27/stable, there's no reason to leave these pins in the wheelhouse.txt

Updates to dependent reactive layers necessitated removing these make way for future builds.

Soon enough this charm will be replaced with an ops version 