### PR TITLE
Add container-runtime and cni endpoints

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -107,6 +107,13 @@ options:
     description: |
       Space-separated list of extra SAN entries to add to the x509 certificate
       created for the control plane nodes.
+  image-registry:
+    type: string
+    default: "rocks.canonical.com:443/cdk"
+    description: |
+      Container image registry to use for CDK. This includes addons like the Kubernetes dashboard,
+      metrics server, ingress, and dns along with non-addon images including the pause
+      container and default backend image.
   scheduler-extra-args:
     type: string
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -97,6 +97,18 @@ options:
         runtime-config=batch/v2alpha1=true profiling=true
       will result in kube-controller-manager being run with the following options:
         --runtime-config=batch/v2alpha1=true --profiling=true
+  default-cni:
+    type: string
+    default: ""
+    description: |
+      Default CNI network to use when multiple CNI subordinates are related.
+
+      The value of this config should be the application name of a related CNI
+      subordinate. For example:
+
+      juju config kubernetes-control-plane default-cni=flannel
+
+      If unspecified, then the default CNI network is chosen alphabetically.
   dns_domain:
     type: string
     default: cluster.local

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,6 +25,9 @@ peers:
   peer:
     interface: kubernetes-control-plane-peer
 provides:
+  cni:
+    interface: kubernetes-cni
+    scope: container
   container-runtime:
     interface: container-runtime
     scope: container

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,6 +25,9 @@ peers:
   peer:
     interface: kubernetes-control-plane-peer
 provides:
+  container-runtime:
+    interface: container-runtime
+    scope: container
   kube-control:
     interface: kube-control
 requires:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp>=3.7.4,<3.8.0
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime@gkk/initial
+charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@gkk/initial
 charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@gkk/subordinates
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 gunicorn >= 20.0.0,<21.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp>=3.7.4,<3.8.0
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
+charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime@gkk/initial
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@gkk/subordinates
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 gunicorn >= 20.0.0,<21.0.0
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 aiohttp>=3.7.4,<3.8.0
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
-charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime@gkk/initial
-charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@gkk/initial
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@gkk/subordinates
+charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime
+charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 gunicorn >= 20.0.0,<21.0.0
 jinja2

--- a/tests/data/overlay.yaml
+++ b/tests/data/overlay.yaml
@@ -4,7 +4,6 @@ applications:
     channel: null
   # Remove the apps we don't support yet
   calico: null
-  containerd: null
   kubernetes-worker: null
 # override machines since we dropped kubernetes-worker
 machines:

--- a/tests/data/overlay.yaml
+++ b/tests/data/overlay.yaml
@@ -5,7 +5,15 @@ applications:
   # Remove the apps we don't support yet
   calico: null
   kubernetes-worker: null
+  # Test CNI with flannel for now, since we don't have kubelet yet
+  flannel:
+    charm: flannel
 # override machines since we dropped kubernetes-worker
 machines:
   "0":
     constraints: "cores=2 mem=8G root-disk=16G"
+relations:
+- - flannel:etcd
+  - etcd:db
+- - flannel:cni
+  - kubernetes-control-plane:cni

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -53,10 +53,12 @@ def test_active(
     get_public_address.return_value = "10.0.0.10"
 
     certificates_relation_id = harness.add_relation("certificates", "easyrsa")
+    container_runtime_relation_id = harness.add_relation("container-runtime", "containerd")
     etcd_relation_id = harness.add_relation("etcd", "etcd")
     peer_relation_id = harness.add_relation("peer", "kubernetes-control-plane")
 
     harness.add_relation_unit(certificates_relation_id, "easyrsa/0")
+    harness.add_relation_unit(container_runtime_relation_id, "containerd/0")
     harness.add_relation_unit(etcd_relation_id, "etcd/0")
 
     harness.update_relation_data(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,6 +25,7 @@ def harness():
 
 @patch("auth_webhook.configure")
 @patch("auth_webhook.get_token")
+@patch("charms.interface_kubernetes_cni.hash_file")
 @patch("charms.kubernetes_snaps.configure_apiserver")
 @patch("charms.kubernetes_snaps.configure_controller_manager")
 @patch("charms.kubernetes_snaps.configure_scheduler")
@@ -32,6 +33,7 @@ def harness():
 @patch("charms.kubernetes_snaps.create_kubeconfig")
 @patch("charms.kubernetes_snaps.get_public_address")
 @patch("charms.kubernetes_snaps.install_snap")
+@patch("charms.kubernetes_snaps.set_default_cni_conf_file")
 @patch("charms.kubernetes_snaps.write_certificates")
 @patch("charms.kubernetes_snaps.write_etcd_client_credentials")
 @patch("charms.kubernetes_snaps.write_service_account_key")
@@ -39,6 +41,7 @@ def test_active(
     write_service_account_key,
     write_etcd_client_credentials,
     write_certificates,
+    set_default_cni_conf_file,
     install_snap,
     get_public_address,
     create_kubeconfig,
@@ -46,18 +49,22 @@ def test_active(
     configure_scheduler,
     configure_controller_manager,
     configure_apiserver,
+    hash_file,
     auth_webhook_get_token,
     auth_webhook_configure,
     harness,
 ):
     get_public_address.return_value = "10.0.0.10"
+    hash_file.return_value = "test-hash"
 
     certificates_relation_id = harness.add_relation("certificates", "easyrsa")
+    cni_relation_id = harness.add_relation("cni", "calico")
     container_runtime_relation_id = harness.add_relation("container-runtime", "containerd")
     etcd_relation_id = harness.add_relation("etcd", "etcd")
     peer_relation_id = harness.add_relation("peer", "kubernetes-control-plane")
 
     harness.add_relation_unit(certificates_relation_id, "easyrsa/0")
+    harness.add_relation_unit(cni_relation_id, "calico/0")
     harness.add_relation_unit(container_runtime_relation_id, "containerd/0")
     harness.add_relation_unit(etcd_relation_id, "etcd/0")
 
@@ -86,6 +93,11 @@ def test_active(
         },
     )
     harness.update_relation_data(
+        cni_relation_id,
+        "calico/0",
+        {"cidr": "192.168.0.0/16", "cni-conf-file": "10-calico.conflist"},
+    )
+    harness.update_relation_data(
         etcd_relation_id,
         "etcd/0",
         {
@@ -110,14 +122,14 @@ def test_active(
         audit_webhook_conf=harness.charm.model.config["audit-webhook-config"],
         auth_webhook_conf="/root/cdk/auth-webhook/auth-webhook-conf.yaml",
         authorization_mode="Node,RBAC",
-        cluster_cidr=None,
+        cluster_cidr="192.168.0.0/16",
         etcd_connection_string="https://10.0.0.11:2379",
         extra_args_config="",
         privileged="auto",
         service_cidr="10.152.183.0/24",
     )
     configure_controller_manager.assert_called_once_with(
-        cluster_cidr=None,
+        cluster_cidr="192.168.0.0/16",
         cluster_name="test-cluster-name",
         extra_args_config="",
         kubeconfig="/root/cdk/kubecontrollermanagerconfig",
@@ -129,6 +141,7 @@ def test_active(
     configure_services_restart_always.assert_called_once_with(control_plane=True)
     create_kubeconfig.assert_called()
     install_snap.assert_called()
+    set_default_cni_conf_file.assert_called_once_with("10-calico.conflist")
     write_certificates.assert_called_once_with(
         ca="test-ca",
         client_cert="test-client-cert-apiserver",


### PR DESCRIPTION
Depends on:
- https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps/pull/5
- https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime/pull/1
- https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni/pull/1

This adds the container-runtime and cni relation endpoints to the kubernetes-control-plane charm. We still can't run Calico, since we're not running kubelet yet, but we can at least test with Flannel.