### PR TITLE
Adds ipvs kernel modules to lxd profile

### DIFF
--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -1,6 +1,6 @@
 name: juju-default-k8s-deployment-0
 config:
-  linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,rbd
+  linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,rbd,ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh
   raw.lxc: |
     lxc.apparmor.profile=unconfined
     lxc.mount.auto=proc:rw sys:rw


### PR DESCRIPTION
Required when using kube-proxy in ipvs mode
And the kubernenetes-control-plane charm is running on a LXD container

Fixes LP#2033682