### PR TITLE
LXD profile for Calico required mount point /sys/fs/bpf

### DIFF
--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -1,6 +1,6 @@
 name: juju-default-k8s-deployment-0
 config:
-  linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,rbd
+  linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,rbd,ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh
   raw.lxc: |
     lxc.apparmor.profile=unconfined
     lxc.mount.auto=proc:rw sys:rw

--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -14,3 +14,7 @@ devices:
     path: /dev/kmsg
     source: /dev/kmsg
     type: unix-char
+  sysfsbpf:
+    path: /sys/fs/bpf
+    source: /sys/fs/bpf
+    type: disk


### PR DESCRIPTION
[LP#2034448](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2034448)

This is the workaround that worked for me
Not sure if this is the best approach to expose /sys/fs/bpf to the container of if it would be better to change the [mount point of the Calico pod](https://github.com/charmed-kubernetes/charm-calico/blob/main/upstream/calico/manifests/3.25.1/calico-etcd.yaml#L319) 