### PR TITLE
Revert "LXD profile for Calico required mount point /sys/fs/bpf"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           sudo apt update
           sudo apt install python3-virtualenv -y
           sudo snap install docker --channel=stable
-          sudo snap install charm --channel=2.x/stable --classic
+          sudo snap install charm --channel=3.x/stable --classic
 
       - name: Build Charm
         run:  charm build . -F

--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -14,7 +14,3 @@ devices:
     path: /dev/kmsg
     source: /dev/kmsg
     type: unix-char
-  sysfsbpf:
-    path: /sys/fs/bpf
-    source: /sys/fs/bpf
-    type: disk


### PR DESCRIPTION
Reverts charmed-kubernetes/charm-kubernetes-control-plane#301

Juju doesn't allow `disk` devices in lxd-profile [by default](https://juju.is/docs/juju/use-lxd-profiles). We'll need some other way to expose /sys/fs/bpf or note that it'll take a manual profile change post-deployment.