### PR TITLE
Configure node services

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -142,3 +142,16 @@ options:
       CIDR to use for Kubernetes services. After deployment it is
       only possible to increase the size of the IP range. It is not possible to
       change or shrink the address range after deployment.
+  sysctl:
+    type: string
+    default: "{net.ipv4.conf.all.forwarding: 1, net.ipv4.conf.all.rp_filter: 1, net.ipv4.neigh.default.gc_thresh1: 128, net.ipv4.neigh.default.gc_thresh2: 28672, net.ipv4.neigh.default.gc_thresh3: 32768, net.ipv6.neigh.default.gc_thresh1: 128, net.ipv6.neigh.default.gc_thresh2: 28672, net.ipv6.neigh.default.gc_thresh3: 32768, fs.inotify.max_user_instances: 8192, fs.inotify.max_user_watches: 1048576, kernel.panic: 10, kernel.panic_on_oops: 1, vm.overcommit_memory: 1}"
+    description: |
+      YAML formatted associative array of sysctl values, e.g.:
+      '{kernel.pid_max: 4194303}'. Note that kube-proxy handles
+      the conntrack settings. The proper way to alter them is to
+      use the proxy-extra-args config to set them, e.g.:
+        juju config kubernetes-control-plane proxy-extra-args="conntrack-min=1000000 conntrack-max-per-core=250000"
+        juju config kubernetes-worker proxy-extra-args="conntrack-min=1000000 conntrack-max-per-core=250000"
+      The proxy-extra-args conntrack-min and conntrack-max-per-core can be set to 0 to ignore
+      kube-proxy's settings and use the sysctl settings instead. Note the fundamental difference between
+      the setting of conntrack-max-per-core vs nf_conntrack_max.

--- a/config.yaml
+++ b/config.yaml
@@ -126,6 +126,69 @@ options:
       Container image registry to use for CDK. This includes addons like the Kubernetes dashboard,
       metrics server, ingress, and dns along with non-addon images including the pause
       container and default backend image.
+  kubelet-extra-args:
+    type: string
+    default: ""
+    description: |
+      Space separated list of flags and key=value pairs that will be passed as arguments to
+      kubelet. For example a value like this:
+        runtime-config=batch/v2alpha1=true profiling=true
+      will result in kubelet being run with the following options:
+        --runtime-config=batch/v2alpha1=true --profiling=true
+      Note: As of Kubernetes 1.10.x, many of Kubelet's args have been deprecated, and can
+      be set with kubelet-extra-config instead.
+  kubelet-extra-config:
+    default: "{}"
+    type: string
+    description: |
+      Extra configuration to be passed to kubelet. Any values specified in this
+      config will be merged into a KubeletConfiguration file that is passed to
+      the kubelet service via the --config flag. This can be used to override
+      values provided by the charm.
+
+      The value for this config must be a YAML mapping that can be safely
+      merged with a KubeletConfiguration file. For example:
+        {evictionHard: {memory.available: 200Mi}}
+
+      For more information about KubeletConfiguration, see upstream docs:
+      https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+  proxy-extra-args:
+    type: string
+    default: ""
+    description: |
+      Space separated list of flags and key=value pairs that will be passed as arguments to
+      kube-proxy. For example a value like this:
+        runtime-config=batch/v2alpha1=true profiling=true
+      will result in kube-apiserver being run with the following options:
+        --runtime-config=batch/v2alpha1=true --profiling=true
+  proxy-extra-config:
+    default: "{}"
+    type: string
+    description: |
+      Extra configuration to be passed to kube-proxy. Any values specified in
+      this config will be merged into a KubeProxyConfiguration file that is
+      passed to the kube-proxy service via the --config flag. This can be used
+      to override values provided by the charm.
+
+      The value for this config must be a YAML mapping that can be safely
+      merged with a KubeProxyConfiguration file. For example:
+        {mode: ipvs, ipvs: {strictARP: true}}
+
+      For more information about KubeProxyConfiguration, see upstream docs:
+      https://kubernetes.io/docs/reference/config-api/kube-proxy-config.v1alpha1/
+  register-with-taints:
+    type: string
+    default: "node-role.kubernetes.io/control-plane:NoSchedule"
+    description: |
+      Space-separated list of taints to apply to this node at registration time.
+
+      This config is only used at deploy time when Kubelet first registers the
+      node with Kubernetes. To change node taints after deploy time, use kubectl
+      instead.
+
+      For more information, see the upstream Kubernetes documentation about
+      taints:
+      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   scheduler-extra-args:
     type: string
     default: ""

--- a/lxd-profile.yaml
+++ b/lxd-profile.yaml
@@ -1,0 +1,16 @@
+name: juju-default-k8s-deployment-0
+config:
+  linux.kernel_modules: ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,rbd,ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh
+  raw.lxc: |
+    lxc.apparmor.profile=unconfined
+    lxc.mount.auto=proc:rw sys:rw
+    lxc.cgroup.devices.allow=a
+    lxc.cap.drop=
+  security.nesting: true
+  security.privileged: true
+description: ""
+devices:
+  aadisable:
+    path: /dev/kmsg
+    source: /dev/kmsg
+    type: unix-char

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp>=3.7.4,<3.8.0
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@gkk/kubelet
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 gunicorn >= 20.0.0,<21.0.0
 jinja2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp>=3.7.4,<3.8.0
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@gkk/kubelet
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 gunicorn >= 20.0.0,<21.0.0
 jinja2

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ import auth_webhook
 import charms.contextual_status as status
 import leader_data
 import ops
+import yaml
 from charms import kubernetes_snaps
 from charms.interface_container_runtime import ContainerRuntimeProvides
 from charms.interface_kubernetes_cni import KubernetesCniProvides
@@ -93,6 +94,10 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             kubeconfig="/root/cdk/kubecontrollermanagerconfig",
             service_cidr=self.model.config["service-cidr"],
         )
+
+    def configure_kernel_parameters(self):
+        sysctl = yaml.safe_load(self.model.config["sysctl"])
+        kubernetes_snaps.configure_kernel_parameters(sysctl)
 
     def configure_scheduler(self):
         kubernetes_snaps.configure_scheduler(
@@ -231,6 +236,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         self.configure_scheduler()
         self.configure_container_runtime()
         self.configure_cni()
+        self.configure_kernel_parameters()
 
     def request_certificates(self):
         """Request client and server certificates."""

--- a/tests/data/overlay.yaml
+++ b/tests/data/overlay.yaml
@@ -3,17 +3,8 @@ applications:
     charm: {{charm}}
     channel: null
   # Remove the apps we don't support yet
-  calico: null
   kubernetes-worker: null
-  # Test CNI with flannel for now, since we don't have kubelet yet
-  flannel:
-    charm: flannel
 # override machines since we dropped kubernetes-worker
 machines:
   "0":
     constraints: "cores=2 mem=8G root-disk=16G"
-relations:
-- - flannel:etcd
-  - etcd:db
-- - flannel:cni
-  - kubernetes-control-plane:cni


### PR DESCRIPTION
Depends on https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps/pull/6

This adds configuration of kubelet and kube-proxy, along with the kernel parameters needed to run them via the `sysctl` config.

Leaving this as a draft PR since requirements.txt will need to be updated.