### PR TITLE
Implement kube-control and loadbalancer relations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -152,6 +152,14 @@ options:
 
       For more information about KubeletConfiguration, see upstream docs:
       https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+  loadbalancer-ips:
+    type: string
+    description: |
+      Space separated list of IP addresses of loadbalancers in front of the control plane.
+      These can be either virtual IP addresses that have been floated in front of the control
+      plane or the IP of a loadbalancer appliance such as an F5. Currently, workers will only
+      use the first address that is specified.
+    default: ""
   proxy-extra-args:
     type: string
     default: ""

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -38,3 +38,11 @@ requires:
     interface: tls-certificates
   etcd:
     interface: etcd
+  loadbalancer-external:
+    # Indicates that the LB should be public facing. Intended for clients which
+    # must reach the API server via external networks.
+    interface: loadbalancer
+  loadbalancer-internal:
+    # Indicates that the LB should not be public and should use internal
+    # networks if available. Intended for control plane and other internal use.
+    interface: loadbalancer

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 gunicorn >= 20.0.0,<21.0.0
 jinja2
+loadbalancer_interface
 ops >= 2.2.0
 ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control@gkk/ops-provides#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-recon
 gunicorn >= 20.0.0,<21.0.0
 jinja2
 ops >= 2.2.0
+ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control@gkk/ops-provides#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
 pydantic < 2
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gunicorn >= 20.0.0,<21.0.0
 jinja2
 loadbalancer_interface
 ops >= 2.2.0
-ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control@gkk/ops-provides#subdirectory=ops
+ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
 pydantic < 2
 tenacity

--- a/src/k8s_api_endpoints.py
+++ b/src/k8s_api_endpoints.py
@@ -63,7 +63,7 @@ class K8sApiEndpoints:
             self.from_config()
             or self.from_lb_internal()
             or self.from_lb_external()
-            or self.from_ingress_addresses()
+            or self.from_ingress_address()
         )
 
     def local(self) -> str:

--- a/src/k8s_api_endpoints.py
+++ b/src/k8s_api_endpoints.py
@@ -1,0 +1,86 @@
+from ipaddress import ip_address
+from typing import Optional
+
+from charms import kubernetes_snaps
+
+
+class K8sApiEndpoints:
+    """Kubernetes API endpoints for this charm."""
+
+    def __init__(self, charm):
+        self.charm = charm
+
+    def from_config(self) -> Optional[str]:
+        """Endpoint URLs from the loadbalancer-ips config option.
+
+        Usually an IP address. Could be a domain name.
+        """
+        addresses = self.charm.model.config["loadbalancer-ips"].split()
+        if addresses:
+            return build_url(addresses[0])
+
+    def from_lb_external(self) -> Optional[str]:
+        """Endpoint URL from the loadbalancer-external relation."""
+        response = self.charm.lb_external.get_response("api-server-external")
+        if not response or response.error:
+            return None
+        return build_url(response.address, 443)
+
+    def from_lb_internal(self) -> Optional[str]:
+        """Endpoint URL from the loadbalancer-internal relation."""
+        response = self.charm.lb_internal.get_response("api-server-internal")
+        if not response or response.error:
+            return None
+        return build_url(response.address, 6443)
+
+    def from_public_address(self) -> str:
+        """Endpoint URL from unit-get public-address."""
+        return build_url(kubernetes_snaps.get_public_address(), 6443)
+
+    def from_ingress_address(self) -> str:
+        """Endpoint URL from kube-control ingress addresses."""
+        return build_url(self.charm.kube_control.ingress_addresses[0], 6443)
+
+    def external(self) -> str:
+        """External or public endpoint URL.
+
+        Should be reachable by users outside of the cluster.
+        """
+        return (
+            self.from_config()
+            or self.from_lb_external()
+            or self.from_lb_internal()
+            or self.from_public_address()
+        )
+
+    def internal(self) -> str:
+        """Return internal endpoint URL.
+
+        Should be reachable by other machines in the cluster. Usually IP
+        addresses, but could sometimes be domain names.
+        """
+        return (
+            self.from_config()
+            or self.from_lb_internal()
+            or self.from_lb_external()
+            or self.from_ingress_addresses()
+        )
+
+    def local(self) -> str:
+        """Local endpoint URL. Only reachable from the local machine."""
+        return build_url("127.0.0.1", 6443)
+
+
+def build_url(address, port):
+    if is_ipv6_address(address):
+        return f"https://[{address}]:{port}"
+    else:
+        return f"https://{address}:{port}"
+
+
+def is_ipv6_address(address):
+    try:
+        address = ip_address(address)
+        return address.version == 6
+    except ValueError:
+        return False

--- a/tests/data/overlay.yaml
+++ b/tests/data/overlay.yaml
@@ -2,9 +2,3 @@ applications:
   kubernetes-control-plane:
     charm: {{charm}}
     channel: null
-  # Remove the apps we don't support yet
-  kubernetes-worker: null
-# override machines since we dropped kubernetes-worker
-machines:
-  "0":
-    constraints: "cores=2 mem=8G root-disk=16G"

--- a/tests/data/overlay.yaml
+++ b/tests/data/overlay.yaml
@@ -2,3 +2,7 @@ applications:
   kubernetes-control-plane:
     charm: {{charm}}
     channel: null
+  etcd:
+    num_units: 1
+  kubernetes-worker:
+    num_units: 1

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -17,7 +17,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
 
     bundle, *overlays = await ops_test.async_render_bundles(
-        ops_test.Bundle("kubernetes-core", channel="edge"), "tests/data/overlay.yaml", charm=charm
+        ops_test.Bundle("charmed-kubernetes", channel="edge"), "tests/data/overlay.yaml", charm=charm
     )
 
     log.info("Deploying bundle")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -17,7 +17,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     charm = await ops_test.build_charm(".")
 
     bundle, *overlays = await ops_test.async_render_bundles(
-        ops_test.Bundle("charmed-kubernetes", channel="edge"), "tests/data/overlay.yaml", charm=charm
+        ops_test.Bundle("charmed-kubernetes", channel="edge"),
+        "tests/data/overlay.yaml",
+        charm=charm,
     )
 
     log.info("Deploying bundle")


### PR DESCRIPTION
Depends on https://github.com/juju-solutions/interface-kube-control/pull/40

Adds the `kube-control`, `loadbalancer-external` and `loadbalancer-internal` relations, along with the `loadbalancer-ips` config option.

This is ready for review, but marked as draft until `requirements.txt` has been updated after the interface-kube-control PR lands.