### PR TITLE
Add cdk-addons and kube-dns relation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,10 +109,43 @@ options:
       juju config kubernetes-control-plane default-cni=flannel
 
       If unspecified, then the default CNI network is chosen alphabetically.
+  default-storage:
+    type: string
+    default: "auto"
+    description: |-
+      The storage class to make the default storage class.
+
+      Setting to "auto" is the same as setting "ceph-xfs"
+
+      Any value is allowed, if it matches the name of a storage class,
+      it alone will be selected as the default storage class for the cluster.
   dns_domain:
     type: string
     default: cluster.local
     description: The local domain for cluster dns
+  dns-provider:
+    type: string
+    default: "auto"
+    description: |
+      DNS provider addon to use. Can be "auto", "core-dns", or "none".
+
+      CoreDNS is only supported on Kubernetes 1.14+.
+
+      When set to "auto", the behavior is as follows:
+      - New deployments of Kubernetes 1.14+ will use CoreDNS
+      - Upgraded deployments will continue to use whichever provider was
+      previously used.
+  enable-dashboard-addons:
+    type: boolean
+    default: true
+    description: Deploy the Kubernetes Dashboard
+  enable-metrics:
+    type: boolean
+    default: true
+    description: |
+      If true the metrics server for Kubernetes will be deployed onto the cluster
+      managed entirely by kubernetes addons. Consider disabling this option and deploying
+      `kubernetes-metrics-server-operator` into a kubernetes model.
   extra_sans:
     type: string
     default: ""

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,6 +36,8 @@ provides:
 requires:
   certificates:
     interface: tls-certificates
+  dns-provider:
+    interface: kube-dns
   etcd:
     interface: etcd
   loadbalancer-external:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp>=3.7.4,<3.8.0
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime
+charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@gkk/initial
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
 charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.7.4,<3.8.0
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime
-charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@gkk/initial
+charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
 charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler

--- a/src/cdk_addons.py
+++ b/src/cdk_addons.py
@@ -1,0 +1,157 @@
+import json
+import logging
+import os
+import shutil
+from subprocess import CalledProcessError, check_call, check_output
+
+from kubectl import kubectl
+from tenacity import retry, stop_after_delay, wait_exponential
+
+kubeconfig_dir = "/root/snap/cdk-addons/common"
+kubeconfig_path = f"{kubeconfig_dir}/kubeconfig"
+log = logging.getLogger(__name__)
+
+
+class CdkAddons:
+    """Class for handling configuration of cdk-addons."""
+
+    def __init__(self, charm):
+        self.charm = charm
+
+    @retry(stop=stop_after_delay(60), wait=wait_exponential())
+    def apply(self):
+        """Apply addons."""
+        check_call(["cdk-addons.apply"])
+
+    def configure(self):
+        """Configure cdk-addons and apply."""
+        if not self.charm.unit.is_leader():
+            return
+
+        # TODO: gpu plugin
+        # load_gpu_plugin = self.charm.model.config["enable-nvidia-plugin"].lower()
+        # gpuEnable = (
+        #     and load_gpu_plugin == "auto"
+        #     and is_state("kubernetes-control-plane.gpu.enabled")
+        # )
+        registry = self.charm.model.config["image-registry"]
+        db_enabled = str(self.charm.model.config["enable-dashboard-addons"]).lower()
+        metrics_enabled = str(self.charm.model.config["enable-metrics"]).lower()
+        default_storage = self.get_default_storage_class()
+
+        args = [
+            "arch=" + arch(),
+            # "ceph-admin-key=" + (ceph.get("admin_key", "")),
+            # "ceph-fsid=" + (ceph.get("fsid", "")),
+            # "ceph-fsname=" + (ceph.get("fsname", "")),
+            # "ceph-kubernetes-key=" + (ceph.get("admin_key", "")),
+            # 'ceph-mon-hosts="' + (ceph.get("mon_hosts", "")) + '"',
+            # "ceph-user=" + hookenv.application_name(),
+            # "cephfs-mounter=" + cephfs_mounter,
+            # "cinder-availability-zone=" + hookenv.config("cinder-availability-zone"),
+            "cluster-tag=" + self.charm.get_cluster_name(),
+            "dashboard-auth=token",
+            "default-storage=" + default_storage,
+            "dns-domain=" + self.charm.model.config["dns_domain"],
+            "dns-provider=" + self.get_dns_provider(),
+            # "enable-aws=" + enable_aws,
+            # "enable-azure=" + enable_azure,
+            # "enable-ceph=" + cephEnabled,
+            # "enable-cephfs=" + cephFsEnabled,
+            "enable-dashboard=" + db_enabled,
+            # "enable-gcp=" + enable_gcp,
+            # "enable-gpu=" + str(gpuEnable).lower(),
+            # "enable-keystone=" + keystoneEnabled,
+            "enable-metrics=" + metrics_enabled,
+            # "enable-openstack=" + enable_openstack,
+            # "keystone-cert-file=" + keystone.get("cert", ""),
+            # "keystone-key-file=" + keystone.get("key", ""),
+            # "keystone-server-ca=" + keystone.get("keystone-ca", ""),
+            # "keystone-server-url=" + keystone.get("url", ""),
+            "kubeconfig=" + kubeconfig_path,
+            # "openstack-cloud-conf=",
+            # "openstack-endpoint-ca=",
+            "registry=" + registry,
+        ]
+        check_call(["snap", "set", "cdk-addons"] + args)
+        self.copy_kubeconfig()
+        self.apply()
+        self.set_default_storage_class()
+
+    def copy_kubeconfig(self):
+        """Copy the admin kubeconfig to a location where cdk-addons can read it."""
+        os.makedirs(kubeconfig_dir, exist_ok=True)
+        shutil.copy("/root/.kube/config", kubeconfig_path)
+
+    def get_default_storage_class(self):
+        """Get the name of the default StorageClass."""
+        def_storage_class = self.charm.model.config["default-storage"]
+        if def_storage_class == "auto":
+            def_storage_class = "ceph-xfs"
+        return def_storage_class
+
+    def get_dns_provider(self):
+        """Get the DNS provider.
+
+        Can return "core-dns" or "none".
+        """
+        valid_dns_providers = ["auto", "core-dns", "none"]
+
+        dns_provider = self.charm.model.config["dns-provider"].lower()
+        if dns_provider not in valid_dns_providers:
+            raise InvalidDnsProviderError(dns_provider)
+
+        if dns_provider == "auto":
+            dns_provider = "core-dns"
+
+        return dns_provider
+
+    def get_storage_classes(self):
+        """Get StorageClasses from Kubernetes."""
+        try:
+            storage_classes = json.loads(kubectl("get", "storageclass", "-o=json"))
+        except (CalledProcessError, FileNotFoundError):
+            log.exception("Failed to get the current storage classes.")
+            storage_classes = {"items": []}
+        for storage_class in storage_classes["items"]:
+            yield storage_class
+
+    def set_default_storage_class(self):
+        """Set the default storage class.
+
+        This applies the storageclass.kubernetes.io/is-default-class annotation
+        to the StorageClass named by the charm's default-storage config option.
+        The annotation is removed from all other StorageClasses.
+        """
+        default_storage_class = self.get_default_storage_class()
+        for storage_class in self.get_storage_classes():
+            name = storage_class["metadata"]["name"]
+            is_default = name == default_storage_class
+            cur_annotations = storage_class["metadata"].get("annotations") or {}
+            new_annotations = cur_annotations.copy()
+            storage_class_annotation = "storageclass.kubernetes.io/is-default-class"
+            if is_default:
+                new_annotations.update(**{storage_class_annotation: "true"})
+            elif not is_default and storage_class_annotation in new_annotations:
+                new_annotations.pop(storage_class_annotation)
+
+            if new_annotations != cur_annotations:
+                log.info(f"{'S' if is_default else 'Uns'}etting default storage-class {name}.")
+                patch_set = json.dumps({"metadata": new_annotations})
+                kubectl("patch", "storageclass", name, "-p", patch_set)
+
+
+class InvalidDnsProviderError(Exception):
+    """Raised when the dns-provider config option is invalid."""
+
+    pass
+
+
+def arch():
+    """Return the package architecture as a string.
+
+    Raise an exception if the architecture is not supported by kubernetes.
+    """
+    architecture = check_output(["dpkg", "--print-architecture"]).rstrip()
+    architecture = architecture.decode("utf-8")
+    return architecture

--- a/src/cdk_addons.py
+++ b/src/cdk_addons.py
@@ -162,5 +162,4 @@ def arch():
     Raise an exception if the architecture is not supported by kubernetes.
     """
     architecture = check_output(["dpkg", "--print-architecture"]).rstrip()
-    architecture = architecture.decode("utf-8")
-    return architecture
+    return architecture.decode("utf-8")

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,6 +13,7 @@ import charms.contextual_status as status
 import leader_data
 import ops
 import yaml
+from cdk_addons import CdkAddons
 from charms import kubernetes_snaps
 from charms.interface_container_runtime import ContainerRuntimeProvides
 from charms.interface_kubernetes_cni import KubernetesCniProvides
@@ -32,6 +33,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.cdk_addons = CdkAddons(self)
         self.certificates = CertificatesRequires(self, endpoint="certificates")
         self.cni = KubernetesCniProvides(
             self, endpoint="cni", default_cni=self.model.config["default-cni"]
@@ -326,6 +328,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             self.configure_kernel_parameters()
             self.configure_kubelet()
             self.configure_kube_proxy()
+            self.cdk_addons.configure()
             self.configure_kube_control()
 
     def request_certificates(self):

--- a/src/kubectl.py
+++ b/src/kubectl.py
@@ -1,9 +1,15 @@
+import json
 import logging
-from subprocess import check_output
+from subprocess import CalledProcessError, check_output
 
 from tenacity import retry, stop_after_delay, wait_exponential
 
 log = logging.getLogger(__name__)
+
+
+def get_service_ip(name, namespace):
+    service = kubectl_get("svc", "-n", namespace, name)
+    return service.get("spec", {}).get("clusterIP")
 
 
 @retry(stop=stop_after_delay(60), wait=wait_exponential())
@@ -14,4 +20,15 @@ def kubectl(*args):
     """
     command = ["kubectl", "--kubeconfig=/root/.kube/config"] + list(args)
     log.info("Executing {}".format(command))
-    return check_output(command).decode("utf-8")
+    try:
+        return check_output(command).decode("utf-8")
+    except CalledProcessError as e:
+        log.error(
+            f"Command failed: {command}\nreturncode: {e.returncode}\nstdout: {e.output.decode()}"
+        )
+        raise
+
+
+def kubectl_get(*args):
+    output = kubectl("get", "-o", "json", *args)
+    return json.loads(output)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,6 +25,7 @@ def harness():
 
 @patch("auth_webhook.configure")
 @patch("auth_webhook.get_token")
+@patch("cdk_addons.CdkAddons.get_dns_address")
 @patch("charms.interface_kubernetes_cni.hash_file")
 @patch("charms.kubernetes_snaps.configure_apiserver")
 @patch("charms.kubernetes_snaps.configure_controller_manager")
@@ -56,10 +57,12 @@ def test_active(
     configure_controller_manager,
     configure_apiserver,
     hash_file,
+    get_dns_address,
     auth_webhook_get_token,
     auth_webhook_configure,
     harness,
 ):
+    get_dns_address.return_value = "10.152.183.10"
     get_public_address.return_value = "10.0.0.10"
     hash_file.return_value = "test-hash"
 
@@ -164,7 +167,7 @@ def test_active(
     configure_kubelet.assert_called_once_with(
         container_runtime_endpoint="test-container-runtime-socket",
         dns_domain="cluster.local",
-        dns_ip=None,
+        dns_ip="10.152.183.10",
         extra_args_config="",
         extra_config={},
         has_xcp=False,


### PR DESCRIPTION
Depends on https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns/pull/1

This adds support for cdk-addons, along with the dns-provider relation endpoint to support using the coredns charm.