### PR TITLE
Label control-plane nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+cni-plugins-*.tar.gz

--- a/config.yaml
+++ b/config.yaml
@@ -185,6 +185,12 @@ options:
 
       For more information about KubeletConfiguration, see upstream docs:
       https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+  labels:
+    type: string
+    default: "node-role.kubernetes.io/control-plane="
+    description: |
+      Labels can be used to organize and to select subsets of nodes in the
+      cluster. Declare node labels in key=value format, separated by spaces.
   loadbalancer-ips:
     type: string
     description: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-l
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens
 charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
+charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@feature/ops-version#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 cosl == 0.0.7
 gunicorn >= 20.0.0,<21.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-l
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens
 charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
-charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@feature/ops-version#subdirectory=ops
+charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 cosl == 0.0.7
 gunicorn >= 20.0.0,<21.0.0

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,7 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import json
-from unittest.mock import patch, call
+from unittest.mock import call, patch
 
 import ops
 import ops.testing
@@ -213,10 +213,12 @@ def test_active(
         ca="test-etcd-ca", cert="test-etcd-client-cert", key="test-etcd-client-key"
     )
     write_service_account_key.assert_called_once_with("test-service-account-key")
-    
-    set_label.assert_has_calls([
-        call("node-role.kubernetes.io/control-plane", ""),
-        call("juju-application", "kubernetes-control-plane"),
-        call("juju-charm", "kubernetes-control-plane"),
-    ])
+
+    set_label.assert_has_calls(
+        [
+            call("node-role.kubernetes.io/control-plane", ""),
+            call("juju-application", "kubernetes-control-plane"),
+            call("juju-charm", "kubernetes-control-plane"),
+        ]
+    )
     remove_label.assert_has_calls([call("juju.io/cloud")])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -42,6 +42,7 @@ def harness():
 @patch("charms.kubernetes_snaps.write_etcd_client_credentials")
 @patch("charms.kubernetes_snaps.write_service_account_key")
 @patch("charm.KubernetesControlPlaneCharm.install_cni_binaries")
+@patch("charm.KubernetesControlPlaneCharm.get_cloud_name")
 @patch("charms.node_base.LabelMaker.active_labels")
 @patch("charms.node_base.LabelMaker.set_label")
 @patch("charms.node_base.LabelMaker.remove_label")
@@ -49,6 +50,7 @@ def test_active(
     remove_label,
     set_label,
     active_labels,
+    get_cloud_name,
     install_cni_binaries,
     write_service_account_key,
     write_etcd_client_credentials,
@@ -70,6 +72,7 @@ def test_active(
     auth_webhook_configure,
     harness,
 ):
+    get_cloud_name.return_value = None
     active_labels.return_value = {}
     get_dns_address.return_value = "10.152.183.10"
     get_public_address.return_value = "10.0.0.10"
@@ -214,11 +217,13 @@ def test_active(
     )
     write_service_account_key.assert_called_once_with("test-service-account-key")
 
+    assert len(set_label.mock_calls) == 3
     set_label.assert_has_calls(
         [
             call("node-role.kubernetes.io/control-plane", ""),
             call("juju-application", "kubernetes-control-plane"),
             call("juju-charm", "kubernetes-control-plane"),
-        ]
+        ],
+        any_order=False,
     )
-    remove_label.assert_has_calls([call("juju.io/cloud")])
+    remove_label.assert_called_once_with("juju.io/cloud")


### PR DESCRIPTION
Use charm config to label the control-plane nodes with user supplied config

Automatically apply labels:
```yaml
  juju-application: <application-name>
  juju-charm: <charm-name>
  juju.io/cloud: <cloud-name if using external control-plane>
``` 

Depends on https://github.com/charmed-kubernetes/layer-kubernetes-node-base/pull/9