### PR TITLE
Fix apiserver forbidden to access kubelet API

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -104,6 +104,9 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             external_cloud_provider=self.external_cloud_provider,
         )
 
+    def configure_apiserver_kubelet_api_admin(self):
+        kubectl("apply", "-f", "templates/apiserver-kubelet-api-admin.yaml")
+
     def configure_auth_webhook(self):
         auth_webhook.configure(
             charm_dir=self.charm_dir,
@@ -422,6 +425,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             self.create_kubeconfigs()
             self.configure_controller_manager()
             self.configure_scheduler()
+            self.configure_apiserver_kubelet_api_admin()
             self.cdk_addons.configure()
             self.configure_container_runtime()
             self.configure_cni()

--- a/templates/apiserver-kubelet-api-admin.yaml
+++ b/templates/apiserver-kubelet-api-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: apiserver-kubelet-api-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kubelet-api-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:kube-apiserver

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,6 +41,7 @@ def harness():
 @patch("charms.kubernetes_snaps.write_certificates")
 @patch("charms.kubernetes_snaps.write_etcd_client_credentials")
 @patch("charms.kubernetes_snaps.write_service_account_key")
+@patch("charm.KubernetesControlPlaneCharm.configure_apiserver_kubelet_api_admin")
 @patch("charm.KubernetesControlPlaneCharm.install_cni_binaries")
 @patch("charm.KubernetesControlPlaneCharm.get_cloud_name")
 @patch("charms.node_base.LabelMaker.active_labels")
@@ -52,6 +53,7 @@ def test_active(
     active_labels,
     get_cloud_name,
     install_cni_binaries,
+    configure_apiserver_kubelet_api_admin,
     write_service_account_key,
     write_etcd_client_credentials,
     write_certificates,
@@ -153,6 +155,7 @@ def test_active(
         service_cidr="10.152.183.0/24",
         external_cloud_provider=harness.charm.external_cloud_provider,
     )
+    configure_apiserver_kubelet_api_admin.assert_called_once_with()
     configure_controller_manager.assert_called_once_with(
         cluster_cidr="192.168.0.0/16",
         cluster_name="test-cluster-name",


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/2043948

This gives kube-apiserver permission to access the kubelet API. This is needed for `kubectl logs` commands to work.

Before fix:
```
$ kubectl logs -n kube-system calico-node-fsb6s calico-node
Error from server (Forbidden): Forbidden (user=system:kube-apiserver, verb=get, resource=nodes, subresource=proxy) ( pods/log calico-node-fsb6s)
```

After fix:
```
$ kubectl logs -n kube-system calico-node-fsb6s calico-node
2023-11-21 21:22:52.781 [INFO][9] startup/startup.go 427: Early log level set to info
2023-11-21 21:22:52.782 [INFO][9] startup/utils.go 130: Using HOSTNAME environment (lowercase) for node name juju-aae02e-4
...
```

This works by binding the `system:kube-apiserver` user to the `system:kubelet-api-admin` ClusterRole, which comes default with Kubernetes. Here are the contents of that ClusterRole:

```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    rbac.authorization.kubernetes.io/autoupdate: "true"
  creationTimestamp: "2023-11-21T21:07:04Z"
  labels:
    kubernetes.io/bootstrapping: rbac-defaults
  name: system:kubelet-api-admin
  resourceVersion: "83"
  uid: 7f69fd81-d40a-481c-8473-9f260b1a3bab
rules:
- apiGroups:
  - ""
  resources:
  - nodes
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - nodes
  verbs:
  - proxy
- apiGroups:
  - ""
  resources:
  - nodes/log
  - nodes/metrics
  - nodes/proxy
  - nodes/stats
  verbs:
  - '*'
```

In the reactive version of this charm, this was handled by the ClusterRole and ClusterRoleBinding in [rbac-proxy.yaml](https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/blob/9ca52889800937509bd0065d285c6646e04cb745/templates/rbac-proxy.yaml). Binding to `system:kubelet-api-admin` instead should fill the same need in a cleaner way.