### PR TITLE
Add config options to adjust load balancer ports

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -380,3 +380,18 @@ options:
     description: |
       Availability zone to use with Cinder CSI. This is passed through to the
       parameters.availability field of the cdk-cinder StorageClass.
+  api-int-lb-port:
+    type: int
+    default:
+    description: |
+      The port that the internal load balancer listens on, defaults to
+      the same as the standard kube-apiserver listen port (6443). This is
+      primarily used where the load balancer needs to run on the same host(s) as
+      the kube-apiserver and both the apiserver and lb cannot bind to 6443.
+  api-ext-lb-port:
+    type: int
+    default:
+    description: |
+      The port that the external load balancer listens on, defaults to 443. This
+      is primarily used where the load balancer needs to run on the same host(s)
+      where another application requires port 443 (eg. kubernetes worker).

--- a/reactive/kubernetes_control_plane.py
+++ b/reactive/kubernetes_control_plane.py
@@ -1446,9 +1446,8 @@ def request_load_balancers():
             continue
         req = lb_provider.get_request("api-server-" + lb_type)
         req.protocol = req.protocols.tcp
-        ext_api_port = kubernetes_control_plane.EXTERNAL_API_PORT
         int_api_port = kubernetes_control_plane.STANDARD_API_PORT
-        api_port = ext_api_port if lb_type == "external" else int_api_port
+        api_port = kubernetes_control_plane.get_lb_port(lb_type)
         req.port_mapping = {api_port: int_api_port}
         req.public = lb_type == "external"
         if not req.health_checks:


### PR DESCRIPTION
api-int-lb-port: sets the load balancer serving port when a loadbalancer-internal relation is specified

api-ext-lb-port: sets the load balancer serving port when a loadbalancer-external relation is specified

These are primarily needed when the kubeapi-load-balancer app is deployed on the same host as either a kubernetes-control-plane or kubernetes-worker node, since the standard ports overlap with the balancer.

Fixes: LP#2042393
https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2042393