### PR TITLE
[LP#2045432] pin yarl<1.9.3

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -26,3 +26,8 @@ ops!=2.1.0
 # rather than pulling in a list of new deps, pin these
 attrs<23.1.0
 urllib3<2.0.0
+
+# yarl>=1.9.3 has changed their build process in such a way
+# its deps aren't pulled into the wheelhouse 
+# https://yarl.aio-libs.org/en/latest/changes/#id3
+yarl<1.9.3


### PR DESCRIPTION
[LP#2045432](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2045432)

yarl 1.9.3 added `expandvars` in the `pyproject.toml ` but the charm tools aren't pulling this dep into the wheelhouse.

I'm guessing that outside of updating charm tools -- we should just pin yarl.