### PR TITLE
Pin config to 1.29/stable snaps and tests to 1.29/stable charms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -85,7 +85,7 @@ options:
       "RBAC", "Node", "Webhook", "ABAC", "AlwaysDeny" and "AlwaysAllow".
   channel:
     type: string
-    default: "1.27/edge"
+    default: "1.29/stable"
     description: |
       Snap channel to install Kubernetes control plane services from
   controller-manager-extra-args:

--- a/tests/integration/test_k8s_control_plane_charm.py
+++ b/tests/integration/test_k8s_control_plane_charm.py
@@ -30,7 +30,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     log.info("Building bundle")
     bundle, *overlays = await ops_test.async_render_bundles(
-        ops_test.Bundle("kubernetes-core", channel="edge"),
+        ops_test.Bundle("kubernetes-core", channel="1.29/stable"),
         Path("tests/data/charm.yaml"),
         arch="amd64",
         charm=charm.resolve(),


### PR DESCRIPTION
Per [release checklist](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#pin-snap-channel-on-bundlescharms-in-the-release-branches)
* Expect integration tests to fail because 1.29/stable charms don't yet exist