### PR TITLE
Don't call `snap list` on the machine running unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 aiohttp>=3.7.4,<3.8.0
-charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
-charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime
-charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider
-charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns
-charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
-charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
-charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
-charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
+charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@release_1.29
+charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime@release_1.29
+charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@release_1.29
+charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@release_1.29
+charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@release_1.29
+charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@release_1.29
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@release_1.29
+charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@release_1.29#subdirectory=ops
+charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@release_1.29
 cosl == 0.0.7
 gunicorn >= 20.0.0,<21.0.0
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster
 jinja2
 loadbalancer_interface
 ops >= 2.2.0
-ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
-ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
+ops.interface_kube_control @ git+https://github.com/charmed-kubernetes/interface-kube-control@release_1.29#subdirectory=ops
+ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@release_1.29#subdirectory=ops
 pydantic < 2
 tenacity

--- a/src/prometheus_alert_rules/charmedKubernetes-prometheusRule.yaml
+++ b/src/prometheus_alert_rules/charmedKubernetes-prometheusRule.yaml
@@ -1,0 +1,11 @@
+groups:
+- name: ssl_cert_expiry_alert
+  rules:
+  - alert: SSLCertificateExpiringSoon
+    expr: probe_ssl_earliest_cert_expiry - time() < 86400 * 15
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "SSL certificate is expiring soon (instance {{ $labels.instance }})"
+      description: "SSL certificate for {{ $labels.instance }} expires in less than 15 days."

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -36,6 +36,7 @@ def harness():
 @patch("charms.kubernetes_snaps.configure_services_restart_always")
 @patch("charms.kubernetes_snaps.create_kubeconfig")
 @patch("charms.kubernetes_snaps.get_public_address")
+@patch("charms.kubernetes_snaps.is_snap_installed")
 @patch("charms.kubernetes_snaps.install_snap")
 @patch("charms.kubernetes_snaps.set_default_cni_conf_file")
 @patch("charms.kubernetes_snaps.write_certificates")
@@ -59,6 +60,7 @@ def test_active(
     write_certificates,
     set_default_cni_conf_file,
     install_snap,
+    is_snap_installed,
     get_public_address,
     create_kubeconfig,
     configure_services_restart_always,
@@ -79,6 +81,7 @@ def test_active(
     get_dns_address.return_value = "10.152.183.10"
     get_public_address.return_value = "10.0.0.10"
     hash_file.return_value = "test-hash"
+    is_snap_installed.return_value = False
 
     certificates_relation_id = harness.add_relation("certificates", "easyrsa")
     cni_relation_id = harness.add_relation("cni", "calico")


### PR DESCRIPTION
Found that unit tests depended on the result of a live test from the host machine's `snap list <app>`.  This call is mocked to return `False`