### PR TITLE
[LP#2046508]  Set application workload version based on the version of kubelet

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -434,7 +434,6 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
     def reconcile(self, event):
         """Reconcile state change events."""
         self.install_cni_binaries()
-        self._set_workload_version()
         kubernetes_snaps.install(channel=self.model.config["channel"], control_plane=True)
         kubernetes_snaps.configure_services_restart_always(control_plane=True)
         self.request_certificates()
@@ -516,6 +515,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
                 self.hacluster.set_node_online()
             else:
                 self.hacluster.set_node_standby()
+        self._set_workload_version()
 
     def write_service_account_key(self):
         peer_relation = self.model.get_relation("peer")

--- a/src/charm.py
+++ b/src/charm.py
@@ -434,6 +434,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
     def reconcile(self, event):
         """Reconcile state change events."""
         self.install_cni_binaries()
+        self._set_workload_version()
         kubernetes_snaps.install(channel=self.model.config["channel"], control_plane=True)
         kubernetes_snaps.configure_services_restart_always(control_plane=True)
         self.request_certificates()
@@ -572,6 +573,20 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         kubernetes_snaps.write_etcd_client_credentials(
             ca=creds["client_ca"], cert=creds["client_cert"], key=creds["client_key"]
         )
+
+    def _set_workload_version(self):
+        cmd = ["kubelet", "--version"]
+        try:
+            version = subprocess.run(cmd, stdout=subprocess.PIPE)
+        except FileNotFoundError:
+            log.warning("kubelet not yet found, skip setting workload version")
+            return
+        if not version.returncode:
+            val = version.stdout.split(b" v")[-1].rstrip().decode()
+            log.info("Setting workload version to %s.", val)
+            self.unit.set_workload_version(val)
+        else:
+            self.unit.set_workload_version("")
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/tests/integration/test_k8s_control_plane_charm.py
+++ b/tests/integration/test_k8s_control_plane_charm.py
@@ -45,3 +45,10 @@ async def test_build_and_deploy(ops_test: OpsTest):
     assert rc == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
 
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 60)
+
+
+def test_status(ops_test):
+    worker_app = ops_test.model.applications["kubernetes-control-plane"]
+    k8s_version_str = worker_app.data["workload-version"]
+    assert k8s_version_str, "Workload version is unset"
+    assert tuple(int(i) for i in k8s_version_str.split(".")[:2]) >= 1.26

--- a/tests/integration/test_k8s_control_plane_charm.py
+++ b/tests/integration/test_k8s_control_plane_charm.py
@@ -51,4 +51,4 @@ def test_status(ops_test):
     worker_app = ops_test.model.applications["kubernetes-control-plane"]
     k8s_version_str = worker_app.data["workload-version"]
     assert k8s_version_str, "Workload version is unset"
-    assert tuple(int(i) for i in k8s_version_str.split(".")[:2]) >= 1.26
+    assert tuple(int(i) for i in k8s_version_str.split(".")[:2]) >= (1, 26)


### PR DESCRIPTION
[LP#2046508](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2046508)

Some tests of charmed-kubernetes require the application workload status be set on the units in order to run correctly.  Also it's surely a very nice bonus at a glance to know which version of the snaps are installed on the units