### PR TITLE
Adds kube-system unit status when the unit is stable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -165,6 +165,13 @@ options:
       DNS entry to use with the HA Cluster subordinate charm.
       Mutually exclusive with ha-cluster-vip.
     default: ""
+  ignore-kube-system-pods:
+    type: string
+    default: ""
+    description: |
+      Space separated list of pod names in the kube-system namespace to ignore
+      when checking for running pods. Any non-Running Pod whose name is on
+      this list, will be ignored during the check.
   image-registry:
     type: string
     default: "rocks.canonical.com:443/cdk"

--- a/src/charm.py
+++ b/src/charm.py
@@ -600,7 +600,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         # 1) currently active status
         # 2) matches a waiting on kube-system message
 
-        kube_system_re = re.compile(r"Waiting for (?:\d+ +)?kube-system pods? to start")
+        kube_system_re = re.compile(r"Waiting for (?:\d+ )?kube-system pods? to start")
         pre_status = self.unit.status
         if isinstance(pre_status, ActiveStatus) or kube_system_re.match(pre_status.message):
             with status.context(self.unit):

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import re
 import shlex
 import socket
 import subprocess
@@ -31,9 +32,10 @@ from charms.reconciler import Reconciler
 from cos_integration import COSIntegration
 from hacluster import HACluster
 from k8s_api_endpoints import K8sApiEndpoints
+from k8s_kube_system import get_kube_system_pods_not_running
 from kubectl import kubectl
 from loadbalancer_interface import LBProvider
-from ops import BlockedStatus, MaintenanceStatus, ModelError, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError, WaitingStatus
 from ops.interface_kube_control import KubeControlProvides
 from ops.interface_tls_certificates import CertificatesRequires
 
@@ -516,6 +518,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             else:
                 self.hacluster.set_node_standby()
         self._set_workload_version()
+        self._check_kube_system()
 
     def write_service_account_key(self):
         peer_relation = self.model.get_relation("peer")
@@ -587,6 +590,28 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             self.unit.set_workload_version(val)
         else:
             self.unit.set_workload_version("")
+
+    def _check_kube_system(self):
+        if not self.reconciler.stored.reconciled:
+            # Bail, the unit isn't reconciled
+            return
+
+        # only update the kube-system status under these conditions
+        # 1) currently active status
+        # 2) matches a waiting on kube-system message
+
+        kube_system_re = re.compile(r"Waiting for (?:\d+ +)?kube-system pods? to start")
+        pre_status = self.unit.status
+        if isinstance(pre_status, ActiveStatus) or kube_system_re.match(pre_status.message):
+            with status.context(self.unit):
+                unready = get_kube_system_pods_not_running(self)
+                if unready is None:
+                    status.add(WaitingStatus("Waiting for kube-system pods to start"))
+                elif unready:
+                    plural = "s" if len(unready) > 1 else ""
+                    msg = "Waiting for {} kube-system pod{} to start"
+                    msg = msg.format(len(unready), plural)
+                    status.add(WaitingStatus(msg))
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/k8s_kube_system.py
+++ b/src/k8s_kube_system.py
@@ -1,0 +1,63 @@
+import logging
+from subprocess import CalledProcessError
+from typing import List, Optional
+
+from kubectl import kubectl_get
+
+log = logging.getLogger(__name__)
+
+
+def get_pods(namespace="default"):
+    try:
+        result = kubectl_get("po", "-n", namespace, "--request-timeout", "10s")
+    except CalledProcessError:
+        log.error("failed to get {} pod status".format(namespace))
+        return None
+    return result
+
+
+def get_kube_system_pods_not_running(charm) -> Optional[List]:
+    """Check pod status in the kube-system namespace.
+
+    returns None if unable to determine pod status. This can
+    occur when the api server is not currently running. On success,
+    returns a list of pods that are not currently running
+    or an empty list if all are running, ignoring pods whose names
+    start with those provided in the ignore-kube-system-pods config option.
+    """
+    result = get_pods("kube-system")
+    if result is None:
+        return None
+
+    # Remove pods whose names start with ones provided in the ignore list
+    pod_names_space_separated = charm.config.get("ignore-kube-system-pods") or ""
+    ignore_list = pod_names_space_separated.strip().split()
+    result["items"] = [
+        pod
+        for pod in result["items"]
+        if not any(pod["metadata"]["name"].startswith(name) for name in ignore_list)
+    ]
+
+    log.info(
+        "Checking system pods status: {}".format(
+            ", ".join(
+                "=".join([pod["metadata"]["name"], pod["status"]["phase"]])
+                for pod in result["items"]
+            )
+        )
+    )
+
+    # Pods in phases such as ['Running', 'Succeeded', 'Failed']
+    # should not be considered as pending Pods.
+    valid_phases = ["Running", "Succeeded", "Failed"]
+
+    # Pods that are Running or Evicted (which should re-spawn) are
+    # considered running
+    not_running = [
+        pod
+        for pod in result["items"]
+        if pod["status"]["phase"] not in valid_phases
+        and pod["status"].get("reason", "") != "Evicted"
+    ]
+
+    return not_running


### PR DESCRIPTION
Reinstates a check of the `kube-system` namespace to test if all the PODs within it are in a steady state.