### PR TITLE
[LP#2048683] Only use FQDN node names on AWS when using its cloud-provider

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -39,6 +39,11 @@ provides:
   tokens:
     interface: tokens
 requires:
+  aws:
+    interface: aws-integration
+    description: |
+      [Deprecated] only necessary for upgrades from 1.28 and can be removed after the upgrade
+      There's no need to relate if this is a fresh deployment
   certificates:
     interface: tls-certificates
   dns-provider:

--- a/src/charm.py
+++ b/src/charm.py
@@ -399,7 +399,8 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         return self.external_cloud_provider.name
 
     def get_node_name(self) -> str:
-        return kubernetes_snaps.get_node_name(fqdn=self.get_cloud_name() == "aws")
+        fqdn = self.external_cloud_provider.name == "aws" and self.external_cloud_provider.has_xcp
+        return kubernetes_snaps.get_node_name(fqdn=fqdn)
 
     def install_cni_binaries(self):
         try:


### PR DESCRIPTION
[LP#2048683](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2048683)

The aws-cloud-provider application requires that the node-names be in fqdn format, any node names that don't match this when the provider is operating will be deleted automatically.  This handles an upgrade of the cluster if the cloud-provider is added at a later date.

Don't merge without first merging
* https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps/pull/13