### PR TITLE
Include lb-consumer relation's addresses when requesting certificates

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -527,8 +527,8 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         sans += config_addrs
         sans += ingress_addrs
         sans += k8s_service_addrs
-        sans += self.k8s_api_endpoints.get_external_api_endpoints()
-        sans += self.k8s_api_endpoints.get_internal_api_endpoints()
+        sans += filter(None, [self.k8s_api_endpoints.get_external_api_endpoint()])
+        sans += filter(None, [self.k8s_api_endpoints.get_internal_api_endpoint()])
         sans += extra_sans
         sans = sorted(set(sans))
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -97,6 +97,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         return True
 
     def configure_apiserver(self):
+        status.add(MaintenanceStatus("Configuring API Server"))
         kubernetes_snaps.configure_apiserver(
             advertise_address=self.kube_control.ingress_addresses[0],
             audit_policy=self.model.config["audit-policy"],
@@ -112,6 +113,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         )
 
     def configure_apiserver_kubelet_api_admin(self):
+        status.add(MaintenanceStatus("Configuring API Server kubelet admin"))
         kubectl("apply", "-f", "templates/apiserver-kubelet-api-admin.yaml")
 
     def configure_auth_webhook(self):
@@ -128,11 +130,13 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             status.add(BlockedStatus("Missing container-runtime integration"))
             return
 
+        status.add(MaintenanceStatus("Configuring CRI"))
         registry = self.model.config["image-registry"]
         sandbox_image = kubernetes_snaps.get_sandbox_image(registry)
         self.container_runtime.set_sandbox_image(sandbox_image)
 
     def configure_cni(self):
+        status.add(MaintenanceStatus("Configuring CNI"))
         self.cni.set_image_registry(self.model.config["image-registry"])
         self.cni.set_kubeconfig_hash_from_file("/root/.kube/config")
         self.cni.set_service_cidr(self.model.config["service-cidr"])
@@ -144,6 +148,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             status.add(WaitingStatus("Waiting for cluster name"))
             return
 
+        status.add(MaintenanceStatus("Configuring Controller Manager"))
         kubernetes_snaps.configure_controller_manager(
             cluster_cidr=self.cni.cidr,
             cluster_name=cluster_name,
@@ -165,10 +170,12 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             # there.
 
     def configure_kernel_parameters(self):
+        status.add(MaintenanceStatus("Configuring Kernel Params"))
         sysctl = yaml.safe_load(self.model.config["sysctl"])
         kubernetes_snaps.configure_kernel_parameters(sysctl)
 
     def configure_kube_control(self):
+        status.add(MaintenanceStatus("Configuring Kube Control"))
         dns_address = self.get_dns_address()
         dns_domain = self.get_dns_domain()
         dns_enabled = bool(dns_address)
@@ -204,6 +211,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             self.kube_control.clear_creds()
 
     def configure_kube_proxy(self):
+        status.add(MaintenanceStatus("Configuring Kube Proxy"))
         kubernetes_snaps.configure_kube_proxy(
             cluster_cidr=self.cni.cidr,
             extra_args_config=self.model.config["proxy-extra-args"],
@@ -213,6 +221,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         )
 
     def configure_kubelet(self):
+        status.add(MaintenanceStatus("Configuring Kubelet"))
         kubernetes_snaps.configure_kubelet(
             container_runtime_endpoint=self.container_runtime.socket,
             dns_domain=self.get_dns_domain(),
@@ -230,6 +239,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         if not self.unit.is_leader():
             return
 
+        status.add(MaintenanceStatus("Configuring LoadBalancers"))
         if self.lb_external.is_available:
             req = self.lb_external.get_request("api-server-external")
             req.protocol = req.protocols.tcp
@@ -238,6 +248,12 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             if not req.health_checks:
                 req.add_health_check(protocol=req.protocols.http, port=6443, path="/livez")
             self.lb_external.send_request(req)
+
+            if not self.lb_external.has_response:
+                status.add(WaitingStatus("Waiting for loadbalancer-external"))
+            elif resp := self.lb_external.get_response("api-server-external"):
+                if resp and resp.error:
+                    status.add(BlockedStatus("Blocked by loadbalancer-external"))
 
         if self.lb_internal.is_available:
             req = self.lb_internal.get_request("api-server-internal")
@@ -248,13 +264,22 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
                 req.add_health_check(protocol=req.protocols.http, port=6443, path="/livez")
             self.lb_internal.send_request(req)
 
+            if not self.lb_internal.has_response:
+                status.add(WaitingStatus("Waiting for loadbalancer-internal"))
+            elif resp := self.lb_internal.get_response("api-server-internal"):
+                if resp and resp.error:
+                    status.add(BlockedStatus("Blocked by loadbalancer-internal"))
+
+
     def configure_scheduler(self):
+        status.add(MaintenanceStatus("Configuring Scheduler"))
         kubernetes_snaps.configure_scheduler(
             extra_args_config=self.model.config["scheduler-extra-args"],
             kubeconfig="/root/cdk/kubeschedulerconfig",
         )
 
     def create_kubeconfigs(self):
+        status.add(MaintenanceStatus("Creating kubeconfigs"))
         ca = self.certificates.ca
         local_server = self.k8s_api_endpoints.local()
         node_name = self.get_node_name()
@@ -341,6 +366,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
     def configure_observability(self):
         """Apply observability configurations to the cluster."""
         # Apply Clusterrole and Clusterrole binding for COS observability
+        status.add(MaintenanceStatus("Configuring Observability"))
         if self.unit.is_leader():
             kubectl("apply", "-f", "templates/observability.yaml")
         # Issue a token for metrics scraping
@@ -355,6 +381,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         if not self.unit.is_leader():
             return
 
+        status.add(MaintenanceStatus("Generating Tokens"))
         self.tokens.remove_stale_tokens()
 
         for request in self.tokens.token_requests:
@@ -503,8 +530,10 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         sans += config_addrs
         sans += ingress_addrs
         sans += k8s_service_addrs
+        sans += self.k8s_api_endpoints.get_external_api_endpoints()
+        sans += self.k8s_api_endpoints.get_internal_api_endpoints()
         sans += extra_sans
-        sans = list(set(sans))
+        sans = sorted(set(sans))
 
         self.certificates.request_client_cert("system:kube-apiserver")
         self.certificates.request_server_cert(cn=common_name, sans=sans)

--- a/src/k8s_api_endpoints.py
+++ b/src/k8s_api_endpoints.py
@@ -31,12 +31,14 @@ class K8sApiEndpoints:
                     return build_url(addresses[0], 6443)
 
     def get_external_api_endpoint(self) -> Optional[str]:
+        """Endpoint address from the loadbalancer-external relation."""
         response = self.charm.lb_external.get_response("api-server-external")
         if not response or response.error:
             return None
         return response.address
 
     def get_internal_api_endpoint(self) -> Optional[str]:
+        """Endpoint address from the loadbalancer-external relation."""
         response = self.charm.lb_external.get_response("api-server-internal")
         if not response or response.error:
             return None

--- a/src/k8s_api_endpoints.py
+++ b/src/k8s_api_endpoints.py
@@ -1,5 +1,5 @@
 from ipaddress import ip_address
-from typing import Optional
+from typing import Optional, List
 
 from charms import kubernetes_snaps
 
@@ -29,6 +29,18 @@ class K8sApiEndpoints:
                 addresses = self.charm.config[key].split()
                 if addresses:
                     return build_url(addresses[0], 6443)
+
+    def get_external_api_endpoints(self) -> List[str]:
+        response = self.charm.lb_external.get_response("api-server-external")
+        if not response or response.error:
+            return []
+        return [response.address]
+
+    def get_internal_api_endpoints(self) -> List[str]:
+        response = self.charm.lb_external.get_response("api-server-internal")
+        if not response or response.error:
+            return []
+        return [response.address]
 
     def from_lb_external(self) -> Optional[str]:
         """Endpoint URL from the loadbalancer-external relation."""

--- a/src/k8s_api_endpoints.py
+++ b/src/k8s_api_endpoints.py
@@ -1,5 +1,5 @@
 from ipaddress import ip_address
-from typing import Optional, List
+from typing import List, Optional
 
 from charms import kubernetes_snaps
 

--- a/src/k8s_api_endpoints.py
+++ b/src/k8s_api_endpoints.py
@@ -1,5 +1,5 @@
 from ipaddress import ip_address
-from typing import List, Optional
+from typing import Optional
 
 from charms import kubernetes_snaps
 
@@ -30,31 +30,27 @@ class K8sApiEndpoints:
                 if addresses:
                     return build_url(addresses[0], 6443)
 
-    def get_external_api_endpoints(self) -> List[str]:
+    def get_external_api_endpoint(self) -> Optional[str]:
         response = self.charm.lb_external.get_response("api-server-external")
         if not response or response.error:
-            return []
-        return [response.address]
+            return None
+        return response.address
 
-    def get_internal_api_endpoints(self) -> List[str]:
+    def get_internal_api_endpoint(self) -> Optional[str]:
         response = self.charm.lb_external.get_response("api-server-internal")
         if not response or response.error:
-            return []
-        return [response.address]
+            return None
+        return response.address
 
     def from_lb_external(self) -> Optional[str]:
         """Endpoint URL from the loadbalancer-external relation."""
-        response = self.charm.lb_external.get_response("api-server-external")
-        if not response or response.error:
-            return None
-        return build_url(response.address, 443)
+        ep = self.get_external_api_endpoint()
+        return ep and build_url(ep, 443)
 
     def from_lb_internal(self) -> Optional[str]:
         """Endpoint URL from the loadbalancer-internal relation."""
-        response = self.charm.lb_internal.get_response("api-server-internal")
-        if not response or response.error:
-            return None
-        return build_url(response.address, 6443)
+        ep = self.get_internal_api_endpoint()
+        return ep and build_url(ep, 6443)
 
     def from_public_address(self) -> str:
         """Endpoint URL from unit-get public-address."""

--- a/tests/integration/test_k8s_control_plane_charm.py
+++ b/tests/integration/test_k8s_control_plane_charm.py
@@ -44,10 +44,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
     rc, stdout, stderr = await ops_test.run(*cmd)
     assert rc == 0, f"Bundle deploy failed: {(stderr or stdout).strip()}"
 
-    await ops_test.model.wait_for_idle(status="active", timeout=60 * 60)
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(status="active", timeout=60 * 60)
 
 
-def test_status(ops_test):
+async def test_status(ops_test):
     worker_app = ops_test.model.applications["kubernetes-control-plane"]
     k8s_version_str = worker_app.data["workload-version"]
     assert k8s_version_str, "Workload version is unset"

--- a/tox.ini
+++ b/tox.ini
@@ -66,10 +66,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest
-    juju
     pytest-operator
-    -r {tox_root}/requirements.txt
 commands =
     pytest -v \
            -s \


### PR DESCRIPTION
The `sans` argument of the certificate request lists which ips or hostnames are included in the certificate generated by the certificate authority (easyrsa or vault)

When we're using a loadbalancer for the k8s-api whether external or internal , the  address from the loadbalancer must be in the sans list.

* include those addresses in the `sans`
* if there are errors from the loadbalancer, report those with a blocking
* while waiting on the loadbalancer, reporting waiting status
* add other Maintenance status tasks