### PR TITLE
LP 2049953: adding coordinator peer interface

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,11 +22,11 @@ series:
   - jammy
   - focal
 peers:
+  coordinator:
+    # LP:2049953 needed for upgrading from < 1.29
+    interface: coordinator
   peer:
     interface: kubernetes-control-plane-peer
-  coordinator:
-￼    # LP:2049953 needed for upgrading from < 1.29
-￼    interface: coordinator
 provides:
   cni:
     interface: kubernetes-cni

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,6 @@ display-name: Kubernetes Control Plane
 summary: The Kubernetes control plane.
 maintainers:
   - Kevin Monroe <kevin.monroe@canonical.com>
-  - George Kraft <george.kraft@canonical.com>
   - Mateo Florido <mateo.florido@canonical.com>
   - Adam Dyess <adam.dyess@canonical.com>
 description: |
@@ -25,6 +24,9 @@ series:
 peers:
   peer:
     interface: kubernetes-control-plane-peer
+  coordinator:
+￼    # LP:2049953 needed for upgrading from < 1.29
+￼    interface: coordinator
 provides:
   cni:
     interface: kubernetes-cni


### PR DESCRIPTION
[LP#2049953](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2049953)

See bug for details. Drive-by to update active maintainers.