### PR TITLE
enforce juju >= 3.1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,9 +18,8 @@ tags:
   - master  # wokeignore:rule=master
   - control-plane
 subordinate: false
-series:
-  - jammy
-  - focal
+assumes:
+  - juju >= 3.1
 peers:
   coordinator:
     # LP:2049953 needed for upgrading from < 1.29


### PR DESCRIPTION
[LP:2051857](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2051857)

Ensure this charm only deploys in juju 3.1+ environments.

FYI to reviewers: series and assumes metadata keys are mutually exclusive. We can safely drop series here since that is now controlled by charmcraft.yaml's builds-on / runs-on directives.