### PR TITLE
Handle Tenacity `RetryError`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ import auth_webhook
 import charms.contextual_status as status
 import leader_data
 import ops
+import tenacity
 import yaml
 from cdk_addons import CdkAddons
 from charms import kubernetes_snaps
@@ -268,6 +269,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             kubeconfig="/root/cdk/kubeschedulerconfig",
         )
 
+    @status.on_error(ops.WaitingStatus("Waiting for Auth Tokens"), tenacity.RetryError)
     def create_kubeconfigs(self):
         status.add(ops.MaintenanceStatus("Creating kubeconfigs"))
         ca = self.certificates.ca


### PR DESCRIPTION
## Overview
Handle `RetryError` in `create-kubeconfigs`
### Rationale
We have seen that in the `edge` builds of Charmed Kubernetes, sometimes the control plane units fail to get the token from the authentication webhook. This causes an exception in the `create_kubeconfigs` method, which due to the unhandled exception, puts the charm in an error state.

## Further Information
https://github.com/charmed-kubernetes/charm-kubernetes-e2e/actions/runs/7790037083