### PR TITLE
Catch missing peer relation during charm upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,15 @@ target-version = ["py38"]
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
-extend-ignore = [
+ignore = [
     "D100",
     "D102",
     "D103",
+    "D107",
     "D203",
     "D204",
     "D213",
@@ -33,12 +37,11 @@ extend-ignore = [
     "D408",
     "D409",
     "D413",
+    "E501",
 ]
-ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.codespell]

--- a/src/charm.py
+++ b/src/charm.py
@@ -561,16 +561,16 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         key = kubernetes_snaps.create_service_account_key()
         peer_relation.data[self.app]["service-account-key"] = key
 
+    @status.on_error(ops.WaitingStatus("Waiting for certificates"))
     def write_certificates(self):
         """Write certificates from the certificates relation."""
         common_name = kubernetes_snaps.get_public_address()
         ca = self.certificates.ca
         client_cert = self.certificates.client_certs_map.get("system:kube-apiserver")
         server_cert = self.certificates.server_certs_map.get(common_name)
-
-        if not ca or not client_cert or not server_cert:
-            status.add(ops.WaitingStatus("Waiting for certificates"))
-            return
+        assert ca, "CA Certificate not ready"
+        assert client_cert, "Client Cert not ready"
+        assert server_cert, "Server Cert not ready"
 
         kubernetes_snaps.write_certificates(
             ca=ca,


### PR DESCRIPTION
Catches a missing peer relation during one of the upgrade-charm hook stages, and awaits its resolution. 

While preparing the `service-account-key` during a charm upgrade to be shared across the cluster via a peer relation, the standby units may come up without this relation and raise an exception while trying to access the `.data` attribute out of `None`

Similarly, the method `get_cluster_name()` could return `None` which failed on the non-leader units when trying to set the value in the `kube-control` relation.  It's possible to also trap those errors and prevent them from showing up as errored juju units. 