### PR TITLE
open the apiserver port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -478,12 +478,10 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             self.apply_node_labels()
             self.open_ports()
 
+    @status.on_error(ops.WaitingStatus("Waiting to open port"))
     def open_ports(self):
         """Open control plane ports needed for remote access to the cluster."""
-        try:
-            self.unit.open_port("tcp", self.APISERVER_PORT)
-        except ops.ModelError:
-            log.warning(f"Failed to open port {self.APISERVER_PORT}. Will retry.")
+        self.unit.open_port("tcp", self.APISERVER_PORT)
 
     def apply_node_labels(self):
         """Request client and server certificates."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -48,7 +48,9 @@ def harness():
 @patch("charms.node_base.LabelMaker.active_labels")
 @patch("charms.node_base.LabelMaker.set_label")
 @patch("charms.node_base.LabelMaker.remove_label")
+@patch("ops.Unit.open_port")
 def test_active(
+    open_port,
     remove_label,
     set_label,
     active_labels,
@@ -233,3 +235,4 @@ def test_active(
         any_order=False,
     )
     remove_label.assert_called_once_with("juju.io/cloud")
+    open_port.assert_called_once_with("tcp", 6443)


### PR DESCRIPTION
[LP:2053048](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2053048)

Looks like we forgot to bring `open_port` over with the ops rewrite. You wouldn't notice it on a default `charmed-kubernetes` install because of k-l-b, but on `kubernetes-core`, you won't be able to access k-c-p outside of the cluster.

See bug for details.