### PR TITLE
add choice betwee root and ubuntu config in kubectl helper

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -453,7 +453,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
 
     def get_kubeconfig(self, event: ops.ActionEvent):
         try:
-            result = kubectl("config", "view", "-o", "json", "--raw")
+            result = kubectl("config", "view", "-o", "json", "--raw", external=True)
             # JSON format verification
             kubeconfig = json.dumps(json.loads(result))
             event.set_results({"kubeconfig": kubeconfig})

--- a/src/kubectl.py
+++ b/src/kubectl.py
@@ -23,7 +23,7 @@ def kubectl(*args, external=False):
     Returns stdout and throws an error if the command fails.
     """
     cfg = "/home/ubuntu/config" if external else "/root/.kube/config"
-    command = ["kubectl", f"--kubeconfig={cfg}"] + list(args)
+    command = ["kubectl", f"--kubeconfig={cfg}", *args]
     log.info("Executing {}".format(command))
     try:
         return check_output(command).decode("utf-8")

--- a/src/kubectl.py
+++ b/src/kubectl.py
@@ -13,12 +13,17 @@ def get_service_ip(name, namespace):
 
 
 @retry(stop=stop_after_delay(60), wait=wait_exponential())
-def kubectl(*args):
+def kubectl(*args, external=False):
     """Run a kubectl cli command with a config file.
+
+    By default, this function uses the root kubeconfig that points to the local apiserver.
+    Setting the 'external' parameter to 'True' will use the ubuntu config which points to
+    the external cluster endpoint.
 
     Returns stdout and throws an error if the command fails.
     """
-    command = ["kubectl", "--kubeconfig=/root/.kube/config"] + list(args)
+    cfg = "/home/ubuntu/config" if external else "/root/.kube/config"
+    command = ["kubectl", f"--kubeconfig={cfg}"] + list(args)
     log.info("Executing {}".format(command))
     try:
         return check_output(command).decode("utf-8")

--- a/tests/unit/test_kubectl.py
+++ b/tests/unit/test_kubectl.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+import kubectl
+
+
+def test_kubectl():
+    """Verify kubectl uses the appropriate kubeconfig files."""
+    int_cfg = "--kubeconfig=/root/.kube/config"
+    ext_cfg = "--kubeconfig=/home/ubuntu/config"
+
+    with patch("kubectl.check_output") as mock:
+        kubectl.kubectl()
+        assert int_cfg in mock.call_args.args[0]
+
+    with patch("kubectl.check_output") as mock:
+        kubectl.kubectl(external=True)
+        assert ext_cfg in mock.call_args.args[0]


### PR DESCRIPTION
[LP#2054126](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2054126)

Follow on to #335. For the `get-kubeconfig` action, we need to use the public kubeconfig stored at `/home/ubuntu/config`. This has the external LB / apiserver endpoint configured.  The root kubeconfig uses localhost:6443, which is highly useless for admins that want to get at their cluster remotely :).