### PR TITLE
Integrate with AWS cloud to appropriately tag control-plane instances

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -42,9 +42,6 @@ provides:
 requires:
   aws:
     interface: aws-integration
-    description: |
-      [Deprecated] only necessary for upgrades from 1.28 and can be removed after the upgrade
-      There's no need to relate if this is a fresh deployment
   certificates:
     interface: tls-certificates
   dns-provider:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ loadbalancer_interface
 ops >= 2.2.0
 ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
+ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration@KU-437/aws-ops-integration#subdirectory=ops
 pydantic < 2
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ loadbalancer_interface
 ops >= 2.2.0
 ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
-ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration@KU-437/aws-ops-integration#subdirectory=ops
+ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration@main#subdirectory=ops
 pydantic < 2
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ loadbalancer_interface
 ops >= 2.2.0
 ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
-ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration@main#subdirectory=ops
+ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration#subdirectory=ops
 pydantic < 2
 tenacity

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,6 @@ import leader_data
 import ops
 import tenacity
 import yaml
-from cloud_integration import CloudIntegration
 from cdk_addons import CdkAddons
 from charms import kubernetes_snaps
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
@@ -33,6 +32,7 @@ from charms.interface_tokens import TokensProvider
 from charms.kubernetes_libs.v0.etcd import EtcdReactiveRequires
 from charms.node_base import LabelMaker
 from charms.reconciler import Reconciler
+from cloud_integration import CloudIntegration
 from cos_integration import COSIntegration
 from hacluster import HACluster
 from k8s_api_endpoints import K8sApiEndpoints
@@ -391,6 +391,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
 
     @status.on_error(ops.WaitingStatus("Waiting for cluster name"))
     def get_cluster_name(self) -> str:
+        """Get the cluster name from the kube-control relation."""
         peer_relation = self.model.get_relation("peer")
         assert peer_relation, "Peer relation not ready"
         cluster_name = peer_relation.data[self.app].get("cluster-name")

--- a/src/charm.py
+++ b/src/charm.py
@@ -496,7 +496,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             self.manage_ports(self.unit.open_port)
         else:
             self.manage_ports(self.unit.close_port)
-        self.cloud_integration.integrate()
+        self.cloud_integration.integrate(event)
 
     @status.on_error(ops.WaitingStatus("Waiting to manage port"))
     def manage_ports(self, port_action: Callable):

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -44,6 +44,7 @@ class CloudIntegration:
             log.error(
                 "Skipping Cloud integration: unsupported cloud %s",
             )
+            return
 
         if not cloud.relation:
             log.info(

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -1,3 +1,8 @@
+# Copyright 2024 Canonical
+# See LICENSE file for licensing details.
+
+"""Cloud Integration for Charmed Kubernetes Worker."""
+
 import logging
 
 import charms.contextual_status as status
@@ -21,22 +26,29 @@ class CloudIntegration:
     """
 
     def __init__(self, charm: ops.CharmBase) -> None:
+        """Integrate with all possible clouds."""
         self.charm = charm
         self.aws = AWSIntegrationRequires(charm)
-        self.gcp = None # GCPIntegrationRequires(charm)
-        self.azure = None # AzureIntegrationRequires(charm)
+        self.gcp = None  # GCPIntegrationRequires(charm)
+        self.azure = None  # AzureIntegrationRequires(charm)
 
     def integrate(self):
         """Request tags and permissions for a control-plane node."""
         cluster_tag = self.charm.get_cluster_name()
         cloud_name = self.charm.get_cloud_name()
-        cloud_support = {"aws": self.aws,}
-        
+        cloud_support = {
+            "aws": self.aws,
+        }
+
         if not (cloud := cloud_support.get(cloud_name)):
-            log.error("Skipping Cloud integration: unsupported cloud %s", )
+            log.error(
+                "Skipping Cloud integration: unsupported cloud %s",
+            )
 
         if not cloud.relation:
-            log.info("Skipping Cloud integration: Needs an active %s relation to integrate.", cloud_name)
+            log.info(
+                "Skipping Cloud integration: Needs an active %s relation to integrate.", cloud_name
+            )
             return
 
         status.add(ops.MaintenanceStatus(f"Integrate with {cloud}"))

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -32,7 +32,8 @@ class CloudIntegration:
         self.gcp = None  # GCPIntegrationRequires(charm)
         self.azure = None  # AzureIntegrationRequires(charm)
 
-    def integrate(self):
+    @status.on_error(ops.WaitingStatus("Waiting for cloud-integration"))
+    def integrate(self, event: ops.EventBase):
         """Request tags and permissions for a control-plane node."""
         cluster_tag = self.charm.get_cluster_name()
         cloud_name = self.charm.get_cloud_name()
@@ -87,3 +88,4 @@ class CloudIntegration:
         cloud.enable_network_management()
         cloud.enable_dns_management()
         cloud.enable_block_storage_management()
+        assert cloud.evaluate_relation(event) is None

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -52,22 +52,11 @@ class CloudIntegration:
 
         status.add(ops.MaintenanceStatus(f"Integrate with {cloud_name}"))
         if cloud_name == "aws":
-            cloud.tag_instance(
-                {
-                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
-                    "k8s.io/role/master": "true",  # wokeignore:rule=master
-                }
-            )
-            cloud.tag_instance_security_group(
-                {
-                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
-                }
-            )
-            cloud.tag_instance_subnet(
-                {
-                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
-                }
-            )
+            aws_cluster_tag = {f"kubernetes.io/cluster/{cluster_tag}": "owned"}
+            # wokeignore:rule=master
+            cloud.tag_instance(aws_cluster_tag | {"k8s.io/role/master": "true"})
+            cloud.tag_instance_security_group(aws_cluster_tag)
+            cloud.tag_instance_subnet(aws_cluster_tag)
             cloud.enable_object_storage_management(["kubernetes-*"])
             cloud.enable_load_balancer_management()
 

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical
 # See LICENSE file for licensing details.
 
-"""Cloud Integration for Charmed Kubernetes Worker."""
+"""Cloud Integration for Charmed Kubernetes Control Plane."""
 
 import logging
 

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -41,9 +41,7 @@ class CloudIntegration:
         }
 
         if not (cloud := cloud_support.get(cloud_name)):
-            log.error(
-                "Skipping Cloud integration: unsupported cloud %s",
-            )
+            log.error("Skipping Cloud integration: unsupported cloud %s", cloud_name)
             return
 
         if not cloud.relation:
@@ -52,7 +50,7 @@ class CloudIntegration:
             )
             return
 
-        status.add(ops.MaintenanceStatus(f"Integrate with {cloud}"))
+        status.add(ops.MaintenanceStatus(f"Integrate with {cloud_name}"))
         if cloud_name == "aws":
             cloud.tag_instance(
                 {

--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -1,0 +1,89 @@
+import logging
+
+import charms.contextual_status as status
+import ops
+from ops.interface_aws.requires import AWSIntegrationRequires
+
+log = logging.getLogger(__name__)
+
+
+class CloudIntegration:
+    """Utility class that handles the integration with clouds for Charmed Kubernetes.
+
+    This class provides methods to configure instance tags and roles for control-plane
+    units
+
+    Attributes:
+        charm (CharmBase): Reference to the base charm instance.
+        aws (AWSIntegrationRequires): Reference to relation integration
+        gcp (GCPIntegrationRequires): Reference to relation integration
+        azure (AzureIntegrationRequires): Reference to relation integration
+    """
+
+    def __init__(self, charm: ops.CharmBase) -> None:
+        self.charm = charm
+        self.aws = AWSIntegrationRequires(charm)
+        self.gcp = None # GCPIntegrationRequires(charm)
+        self.azure = None # AzureIntegrationRequires(charm)
+
+    def integrate(self):
+        """Request tags and permissions for a control-plane node."""
+        cluster_tag = self.charm.get_cluster_name()
+        cloud_name = self.charm.get_cloud_name()
+        cloud_support = {"aws": self.aws,}
+        
+        if not (cloud := cloud_support.get(cloud_name)):
+            log.error("Skipping Cloud integration: unsupported cloud %s", )
+
+        if not cloud.relation:
+            log.info("Skipping Cloud integration: Needs an active %s relation to integrate.", cloud_name)
+            return
+
+        status.add(ops.MaintenanceStatus(f"Integrate with {cloud}"))
+        if cloud_name == "aws":
+            cloud.tag_instance(
+                {
+                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
+                    "k8s.io/role/master": "true",  # wokeignore:rule=master
+                }
+            )
+            cloud.tag_instance_security_group(
+                {
+                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
+                }
+            )
+            cloud.tag_instance_subnet(
+                {
+                    f"kubernetes.io/cluster/{cluster_tag}": "owned",
+                }
+            )
+            cloud.enable_object_storage_management(["kubernetes-*"])
+            cloud.enable_load_balancer_management()
+
+            # Necessary for cloud-provider-aws
+            cloud.enable_autoscaling_readonly()
+            cloud.enable_instance_modification()
+            cloud.enable_region_readonly()
+        elif cloud_name == "gcp":
+            cloud.tag_instance(
+                {
+                    "k8s-io-cluster-name": cluster_tag,
+                    "k8s-io-role-master": "master",  # wokeignore:rule=master
+                }
+            )
+            cloud.enable_object_storage_management()
+            cloud.enable_security_management()
+        elif cloud_name == "azure":
+            cloud.tag_instance(
+                {
+                    "k8s-io-cluster-name": cluster_tag,
+                    "k8s-io-role-master": "master",  # wokeignore:rule=master
+                }
+            )
+            cloud.enable_object_storage_management()
+            cloud.enable_security_management()
+            cloud.enable_loadbalancer_management()
+        cloud.enable_instance_inspection()
+        cloud.enable_network_management()
+        cloud.enable_dns_management()
+        cloud.enable_block_storage_management()


### PR DESCRIPTION
Adds cloud_integration.py to prepare for all clouds Charmed-Kubernetes must relate to -- starting with AWS

Needs this PR first:
* https://github.com/juju-solutions/interface-aws-integration/pull/17