### PR TITLE
integrate with google cloud gcp relation and external-cloud-provider

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -42,6 +42,8 @@ provides:
 requires:
   aws:
     interface: aws-integration
+  gcp:
+    interface: gcp-integration
   certificates:
     interface: tls-certificates
   dns-provider:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@KU-439/gcp-cloud-integration
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 cosl == 0.0.7
@@ -14,8 +14,10 @@ interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-
 jinja2
 loadbalancer_interface
 ops >= 2.2.0
-ops.interface_kube_control @ git+https://github.com/juju-solutions/interface-kube-control#subdirectory=ops
-ops.interface_tls_certificates @ git+https://github.com/juju-solutions/interface-tls-certificates#subdirectory=ops
-ops.interface_aws @ git+https://github.com/juju-solutions/interface-aws-integration#subdirectory=ops
+ops.interface_kube_control @ git+https://github.com/charmed-kubernetes/interface-kube-control@main#subdirectory=ops
+ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@main#subdirectory=ops
+ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops
+ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@KU-439/gcp-ops-integration#subdirectory=ops
+
 pydantic < 2
 tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@KU-439/gcp-cloud-integration
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 cosl == 0.0.7
@@ -17,7 +17,7 @@ ops >= 2.2.0
 ops.interface_kube_control @ git+https://github.com/charmed-kubernetes/interface-kube-control@main#subdirectory=ops
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@main#subdirectory=ops
 ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops
-ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@KU-439/gcp-ops-integration#subdirectory=ops
+ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops
 
 pydantic < 2
 tenacity


### PR DESCRIPTION
Tests integration with Google Cloud and external provider
* gcp-cloud-provider
* gcp-k8s-storage
* gcp-integrator charms through the ops version of the gcp-integration

Depends on merges of:
* https://github.com/charmed-kubernetes/interface-gcp-integration/pull/1
* https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps/pull/15
