### PR TITLE
set default snap channel to edge on main branch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -85,7 +85,7 @@ options:
       "RBAC", "Node", "Webhook", "ABAC", "AlwaysDeny" and "AlwaysAllow".
   channel:
     type: string
-    default: "1.27/edge"
+    default: "edge"
     description: |
       Snap channel to install Kubernetes control plane services from
   controller-manager-extra-args:


### PR DESCRIPTION
we pin this config on the `release_1.xx` branches; we should let it track edge on the main branch.