### PR TITLE
[LP#2060070] Charm Actions Ops Port

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,4 +1,61 @@
-upgrade:
-    description: Upgrade the Kubernetes snaps
 get-kubeconfig:
   description: Retrieve Kubernetes cluster config, including credentials
+upgrade:
+    description: Upgrade the Kubernetes snaps
+user-create:
+  description: Create a new user
+  params:
+    name:
+      type: string
+      description: |
+        Username for the new user. This value must only contain alphanumeric
+        characters, ':', '@', '-' or '.'.
+      minLength: 2
+    groups:
+      type: string
+      description: |
+        Optional comma-separated list of groups eg. 'system:masters,managers'
+  required:
+    - name
+user-delete:
+  description: Delete an existing user
+  params:
+    name:
+      type: string
+      description: Username of the user to delete
+      minLength: 2
+  required:
+    - name
+user-list:
+  description: List existing users
+restart:
+  description: Restart the Kubernetes control-plane services on demand.
+namespace-list:
+  description: List existing k8s namespaces
+namespace-create:
+  description: Create new namespace
+  params:
+    name:
+      type: string
+      description: Namespace name eg. staging
+      minLength: 2
+  required:
+    - name
+namespace-delete:
+  description: Delete namespace
+  params:
+    name:
+      type: string
+      description: Namespace name eg. staging
+      minLength: 2
+  required:
+    - name
+apply-manifest:
+  description: Apply JSON formatted Kubernetes manifest to cluster
+  params:
+    json:
+      type: string
+      description: The content of the manifest to deploy in JSON format
+      minLength: 2
+  required:
+  - json

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,7 +1,7 @@
 get-kubeconfig:
   description: Retrieve Kubernetes cluster config, including credentials
 upgrade:
-    description: Upgrade the Kubernetes snaps
+  description: Upgrade the Kubernetes snaps
 user-create:
   description: Create a new user
   params:
@@ -51,7 +51,9 @@ namespace-delete:
   required:
     - name
 apply-manifest:
-  description: Apply JSON formatted Kubernetes manifest to cluster
+  description: |
+    Apply JSON formatted Kubernetes manifest to cluster.
+    juju run this action using `--string-args`
   params:
     json:
       type: string

--- a/src/actions/general.py
+++ b/src/actions/general.py
@@ -31,7 +31,7 @@ def apply_manifest(event: ops.ActionEvent):
         event.set_results(
             {
                 "summary": "Manifest applied.",
-                "output": output.decode("utf-8"),
+                "output": output,
             }
         )
     except subprocess.CalledProcessError as e:

--- a/src/actions/kubectl.py
+++ b/src/actions/kubectl.py
@@ -1,0 +1,46 @@
+import json
+import os
+import subprocess
+import tempfile
+
+import ops
+from kubectl import kubectl
+
+
+def get_kubeconfig(event: ops.ActionEvent):
+    try:
+        result = kubectl("config", "view", "-o", "json", "--raw", external=True)
+        # JSON format verification
+        kubeconfig = json.dumps(json.loads(result))
+        event.set_results({"kubeconfig": kubeconfig})
+    except json.JSONDecodeError as e:
+        event.fail("Failed to parse kubeconfig: {}".format(str(e)))
+    except Exception as e:
+        event.fail("Failed to retrieve kubeconfig: {}".format(str(e)))
+
+
+def apply_manifest(event: ops.ActionEvent):
+    """Apply a user defined manifest with kubectl."""
+    _, apply_path = tempfile.mkstemp(suffix=".json")
+    try:
+        manifest = json.loads(event.params["json"])
+        with open(apply_path, "w") as manifest_file:
+            json.dump(manifest, manifest_file)
+        output = kubectl("apply", "-f", apply_path)
+
+        event.set_results(
+            {
+                "summary": "Manifest applied.",
+                "output": output.decode("utf-8"),
+            }
+        )
+    except subprocess.CalledProcessError as e:
+        event.fail(
+            "kubectl failed with exit code {} and message: {}".format(e.returncode, e.output)
+        )
+    except json.JSONDecodeError as e:
+        event.fail("Failed to parse JSON manifest: {}".format(str(e)))
+    except Exception as e:
+        event.fail("Failed to apply manifest: {}".format(str(e)))
+    finally:
+        os.unlink(apply_path)

--- a/src/actions/namespace.py
+++ b/src/actions/namespace.py
@@ -1,0 +1,41 @@
+import os
+
+import ops
+from charmhelpers.core.templating import render
+from kubectl import kubectl
+from yaml import safe_load as load
+
+os.environ["PATH"] += os.pathsep + os.path.join(os.sep, "snap", "bin")
+
+
+def namespace_list(event: ops.ActionEvent):
+    y = load(kubectl("get", "namespaces", "-o", "yaml"))
+    ns = [i["metadata"]["name"] for i in y["items"]]
+    event.set_results({"namespaces": ", ".join(ns) + "."})
+
+
+def namespace_create(event: ops.ActionEvent):
+    name = event.params["name"]
+    if name in namespace_list():
+        event.fail('Namespace "{}" already exists.'.format(name))
+        return
+
+    render(
+        "create-namespace.yaml.j2",
+        "/etc/kubernetes/addons/create-namespace.yaml",
+        context={"name": name},
+    )
+    kubectl("create", "-f", "/etc/kubernetes/addons/create-namespace.yaml")
+    event.set_results({"msg": 'Namespace "{}" created.'.format(name)})
+
+
+def namespace_delete(event: ops.ActionEvent):
+    name = event.params["name"]
+    if name in ["default", "kube-system"]:
+        event.fail('Not allowed to delete "{}".'.format(name))
+        return
+    if name not in namespace_list():
+        event.fail('Namespace "{}" does not exist.'.format(name))
+        return
+    kubectl("delete", "ns/" + name)
+    event.set_results({"msg": 'Namespace "{}" deleted.'.format(name)})

--- a/src/actions/namespace.py
+++ b/src/actions/namespace.py
@@ -1,31 +1,36 @@
 import os
+import tempfile
 
 import ops
-from charmhelpers.core.templating import render
 from kubectl import kubectl
-from yaml import safe_load as load
+from yaml import safe_dump, safe_load
 
 os.environ["PATH"] += os.pathsep + os.path.join(os.sep, "snap", "bin")
 
 
 def namespace_list(event: ops.ActionEvent):
-    y = load(kubectl("get", "namespaces", "-o", "yaml"))
+    y = safe_load(kubectl("get", "namespaces", "-o", "yaml"))
     ns = [i["metadata"]["name"] for i in y["items"]]
     event.set_results({"namespaces": ", ".join(ns) + "."})
+    return ns
 
 
 def namespace_create(event: ops.ActionEvent):
     name = event.params["name"]
-    if name in namespace_list():
+    if name in namespace_list(event):
         event.fail('Namespace "{}" already exists.'.format(name))
         return
 
-    render(
-        "create-namespace.yaml.j2",
-        "/etc/kubernetes/addons/create-namespace.yaml",
-        context={"name": name},
-    )
-    kubectl("create", "-f", "/etc/kubernetes/addons/create-namespace.yaml")
+    ns = {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {"name": name, "labels": {"name": name}},
+    }
+    with tempfile.NamedTemporaryFile("w+") as tmp:
+        tmp.write(safe_dump(ns))
+        tmp.flush()
+        kubectl("create", "-f", tmp.name)
+
     event.set_results({"msg": 'Namespace "{}" created.'.format(name)})
 
 
@@ -34,7 +39,7 @@ def namespace_delete(event: ops.ActionEvent):
     if name in ["default", "kube-system"]:
         event.fail('Not allowed to delete "{}".'.format(name))
         return
-    if name not in namespace_list():
+    if name not in namespace_list(event):
         event.fail('Namespace "{}" does not exist.'.format(name))
         return
     kubectl("delete", "ns/" + name)

--- a/src/actions/restart.py
+++ b/src/actions/restart.py
@@ -1,0 +1,14 @@
+import charms.contextual_status as status
+import ops
+from charms import kubernetes_snaps
+
+
+def restart_action(event: ops.ActionEvent):
+    """Handle the upgrade action."""
+    with status.context(event.framework.model.unit):
+        kubernetes_snaps.service_restart("snap.kube-apiserver.daemon")
+        event.set_results({"api-server": {"status": "restarted"}})
+        kubernetes_snaps.service_restart("snap.kube-controller-manager.daemon")
+        event.set_results({"controller-manager": {"status": "restarted"}})
+        kubernetes_snaps.service_restart("snap.kube-scheduler.daemon")
+        event.set_results({"kube-scheduler": {"status": "restarted"}})

--- a/src/actions/upgrade.py
+++ b/src/actions/upgrade.py
@@ -1,0 +1,10 @@
+import charms.contextual_status as status
+import ops
+from charms import kubernetes_snaps
+
+
+def upgrade_action(event: ops.ActionEvent):
+    """Handle the upgrade action."""
+    with status.context(event.framework.model.unit):
+        channel = event.framework.model.config.get("channel")
+        kubernetes_snaps.upgrade_snaps(channel=channel, event=event, control_plane=True)

--- a/src/actions/users.py
+++ b/src/actions/users.py
@@ -1,0 +1,105 @@
+#!/usr/local/sbin/charm-env python3
+import os
+import re
+
+import ops
+from auth_webhook import create_token, delete_token, get_secrets
+from charms import kubernetes_snaps
+
+
+def protect_resources(name: str, event: ops.ActionEvent) -> bool:
+    """Do not allow the action to operate on names used by Charmed Kubernetes."""
+    protected_names = [
+        "admin",
+        "system:kube-controller-manager",
+        "kube-controller-manager",
+        "system:kube-proxy",
+        "kube-proxy",
+        "system:kube-scheduler",
+        "kube-scheduler",
+        "system:monitoring",
+    ]
+    if name.startswith("kubelet") or name in protected_names:
+        event.fail('Not allowed to {} "{}".'.format(event.id, name))
+        return False
+    return True
+
+
+def user_list(event: ops.ActionEvent):
+    """Return a dict of 'username: secret_id' for Charmed Kubernetes users."""
+    secrets = list(get_secrets())
+    event.set_results({"users": ", ".join(secrets)})
+    return secrets
+
+
+def user_create(charm, event: ops.ActionEvent):
+    user = event.params["name"]
+    groups = event.params.get("groups") or ""
+    if not protect_resources(user, event):
+        return
+
+    users = user_list()
+    if user in list(users):
+        event.fail('User "{}" already exists.'.format(user))
+        return
+
+    # Validate the name
+    if re.search("[^0-9A-Za-z:@.-]+", user):
+        msg = "User name may only contain alphanumeric characters, ':', '@', '-' or '.'"
+        event.fail(msg)
+        return
+
+    # Create the secret
+    if not (token := create_token(user, user, groups)):
+        event.fail("Failed to create secret for: {}".format(user))
+        return
+
+    if not (public_server := charm.k8s_api_endpoints.external()):
+        event.fail("Kubernetes client endpoints currently unavailable.")
+
+    # Create a kubeconfig
+    ca = charm.certificates.ca
+    kubeconfig_path = "/home/ubuntu/{}-kubeconfig".format(user)
+
+    if not os.path.exists(kubeconfig_path):
+        kubernetes_snaps.create_kubeconfig(
+            kubeconfig_path,
+            ca=ca,
+            server=public_server,
+            user=user,
+            token=token,
+        )
+
+    os.chmod(kubeconfig_path, 0o644)
+
+    # Tell the people what they've won
+    fetch_cmd = "juju scp {}:{} .".format(event.framework.model.unit.name, kubeconfig_path)
+    event.set_result(
+        {
+            "msg": 'User "{}" created.'.format(user),
+            "users": ", ".join(list(users) + [user]),
+            "kubeconfig": fetch_cmd,
+        }
+    )
+
+
+def user_delete(event: ops.ActionEvent):
+    user = event.params["name"]
+    if not protect_resources(user, event):
+        return
+
+    users = user_list()
+    if user not in list(users):
+        event.fail('User "{}" does not exist.'.format(user))
+        return
+
+    # Delete the secret
+    secret_id = users[user]
+    delete_token(secret_id)
+
+    event.set_results(
+        {
+            "msg": 'User "{}" deleted.'.format(user),
+            "users": ", ".join(u for u in list(users) if u != user),
+        }
+    )

--- a/src/auth_webhook.py
+++ b/src/auth_webhook.py
@@ -142,7 +142,6 @@ def generate_rfc1123(length=10):
 def get_secrets():
     """Get all the secrets that CK created."""
     output = kubectl_get(
-        "get",
         "secrets",
         "-n",
         auth_secret_ns,

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Callable
 
-import actions.kubectl
+import actions.general
 import actions.namespace
 import actions.upgrade
 import actions.users
@@ -110,17 +110,17 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
 
     def charm_actions(self, event: ops.ActionEvent):
         action_map = {
-            "upgrade": actions.upgrade.upgrade_action,
-            "get-kubeconfig": actions.kubectl.get_kubeconfig,
-            "apply-manifest": actions.kubectl.apply_manifest,
-            "user-create": functools.partial(actions.users.user_create, self),
-            "user-delete": actions.users.user_delete,
-            "user-list": actions.users.user_list,
-            "namespace-create": actions.namespace.namespace_create,
-            "namespace-delete": actions.namespace.namespace_delete,
-            "namespace-list": actions.namespace.namespace_list,
+            "upgrade_action": actions.upgrade.upgrade_action,
+            "get_kubeconfig_action": actions.general.get_kubeconfig,
+            "apply_manifest_action": actions.general.apply_manifest,
+            "user_create_action": functools.partial(actions.users.user_create, self),
+            "user_delete_action": actions.users.user_delete,
+            "user_list_action": actions.users.user_list,
+            "namespace_create_action": actions.namespace.namespace_create,
+            "namespace_delete_action": actions.namespace.namespace_delete,
+            "namespace_list_action": actions.namespace.namespace_list,
         }
-        return action_map[event.id](event)
+        return action_map[event.handle.kind](event)
 
     @status.on_error(ops.WaitingStatus("Waiting on valid certificate data"))
     def api_dependencies_ready(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,7 +4,7 @@
 
 """Charmed Machine Operator for Kubernetes Control Plane."""
 
-import json
+import functools
 import logging
 import os
 import re
@@ -15,6 +15,10 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Callable
 
+import actions.kubectl
+import actions.namespace
+import actions.upgrade
+import actions.users
 import auth_webhook
 import charms.contextual_status as status
 import leader_data
@@ -89,8 +93,34 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         self.tokens = TokensProvider(self, endpoint="tokens")
         self.framework.observe(self.on.update_status, self.update_status)
 
-        self.framework.observe(self.on.upgrade_action, self.on_upgrade_action)
-        self.framework.observe(self.on.get_kubeconfig_action, self.get_kubeconfig)
+        # register charm actions
+        actions = [
+            self.on.upgrade_action,
+            self.on.get_kubeconfig_action,
+            self.on.apply_manifest_action,
+            self.on.user_create_action,
+            self.on.user_delete_action,
+            self.on.user_list_action,
+            self.on.namespace_create_action,
+            self.on.namespace_delete_action,
+            self.on.namespace_list_action,
+        ]
+        for action in actions:
+            self.framework.observe(action, self.charm_actions)
+
+    def charm_actions(self, event: ops.ActionEvent):
+        action_map = {
+            "upgrade": actions.upgrade.upgrade_action,
+            "get-kubeconfig": actions.kubectl.get_kubeconfig,
+            "apply-manifest": actions.kubectl.apply_manifest,
+            "user-create": functools.partial(actions.users.user_create, self),
+            "user-delete": actions.users.user_delete,
+            "user-list": actions.users.user_list,
+            "namespace-create": actions.namespace.namespace_create,
+            "namespace-delete": actions.namespace.namespace_delete,
+            "namespace-list": actions.namespace.namespace_list,
+        }
+        return action_map[event.id](event)
 
     @status.on_error(ops.WaitingStatus("Waiting on valid certificate data"))
     def api_dependencies_ready(self):
@@ -466,23 +496,6 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             raise
 
         log.info(f"Extracted 'cni-plugins' to {unpack_path}")
-
-    def on_upgrade_action(self, event):
-        """Handle the upgrade action."""
-        with status.context(self.unit):
-            channel = self.model.config.get("channel")
-            kubernetes_snaps.upgrade_snaps(channel=channel, event=event, control_plane=True)
-
-    def get_kubeconfig(self, event: ops.ActionEvent):
-        try:
-            result = kubectl("config", "view", "-o", "json", "--raw", external=True)
-            # JSON format verification
-            kubeconfig = json.dumps(json.loads(result))
-            event.set_results({"kubeconfig": kubeconfig})
-        except json.JSONDecodeError as e:
-            event.fail("Failed to parse kubeconfig: {}".format(str(e)))
-        except Exception as e:
-            event.fail("Failed to retrieve kubeconfig: {}".format(str(e)))
 
     def reconcile(self, event):
         """Reconcile state change events."""


### PR DESCRIPTION
[LP#2060070](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2060070)

Port charm actions from reactive to ops that were identified as a gap during the upgrade. 

These are effectively straight port of admin actions available in the charm when it was reactive, addressing no issues with what was present in those previous actions like
* TTL for user token creation
* Validation of manifest application