### PR TITLE
Simplify uplifting the one-shot-token from a reactive upgrade

### DIFF
--- a/src/encryption/reactive.py
+++ b/src/encryption/reactive.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import logging
 import sqlite3
@@ -57,22 +56,6 @@ class UnitsView:
             for unit in sorted(rel.units, key=lambda u: u.name, reverse=True):
                 combined.update(**rel.data[unit])
         return combined
-
-
-def is_data_changed(unit_kv: UnitKV, data_id: str, data: Any, hash_type: str = "md5"):
-    """Check if the given set of data has changed since stored in the .unit-state.db kv table.
-
-    That is, this is a non-destructive way to check if the data has changed.
-
-    :param str data_id: Unique identifier for this set of data.
-    :param data: JSON-serializable data.
-    :param str hash_type: Any hash algorithm supported by :mod:`hashlib`.
-    """
-    alg = getattr(hashlib, hash_type)
-    serialized = json.dumps(data, sort_keys=True).encode("utf8")
-    old_hash = unit_kv.read(f"reactive.data_changed.{data_id}")
-    new_hash = alg(serialized).hexdigest()
-    return old_hash != new_hash
 
 
 # Yanked from charmhelpers

--- a/src/encryption/vault_kv.py
+++ b/src/encryption/vault_kv.py
@@ -225,8 +225,14 @@ class VaultKV(ops.Object):
         self._app_kv.notify()
         return self._app_kv
 
-    def _on_commit(self, _: ops.CommitEvent):
-        """At hook end, ensure the app hash is consistent in VaultKV."""
+    def _on_commit(self, e: ops.CommitEvent):
+        """At hook end, ensure the app hash is consistent in VaultKV.
+
+        By registering the on.commit event, we robbed this object of
+        its natural call to save its own stored state during that event.
+        We just need to call the method here to ensure the data is saved.
+        """
+        self._stored._data.on_commit(e)
         try:
             app_kv = self.app_kv
             if app_kv.any_changed():

--- a/tests/unit/test_vault_kv.py
+++ b/tests/unit/test_vault_kv.py
@@ -76,7 +76,7 @@ def test_get_vault_config_success(mock_retrieve_secret_id, vault_kv, backend_for
         mock_retrieve_secret_id.assert_called_once_with(
             vault_kv_ifc.vault_url, vault_kv_ifc.unit_token
         )
-        assert vault_kv._stored.token == "some-secret-token-value"
+        assert vault_kv._stored.token_hash == "502d4af9f5d1e89c42c20de9d3916db9"
         assert vault_kv._stored.secret_id == "secret-from-token-value"
         assert vault_config == {
             "vault_url": vault_kv_ifc.vault_url,
@@ -94,12 +94,12 @@ def test_get_vault_config_fails_get_secret_id(mock_retrieve_secret_id, vault_kv)
     successful retrieval using the one-time token from `secret_id`
     """
     mock_retrieve_secret_id.side_effect = hvac.exceptions.VaultDown()
-    vault_kv._stored.token = "unchanged"
+    vault_kv._stored.token_hash = "unchanged"
     vault_kv_ifc = vault_kv.requires
     with pytest.raises(VaultNotReadyError):
         vault_kv.get_vault_config()
 
-    assert vault_kv._stored.token == "unchanged"
+    assert vault_kv._stored.token_hash == "unchanged"
     mock_retrieve_secret_id.assert_called_once_with(
         vault_kv_ifc.vault_url, vault_kv_ifc.unit_token
     )


### PR DESCRIPTION
This deviates from the layer-vault-kv -- but i think it's for the better

an md5 hash of the one-shot token is stored in the reactive version of stored_state (unitdata.kv).  We effectively need to read that once, and move it to the storedstate of that VaultKV object.  Remember -- this is a hash of the token.  It's not the one-shot token itself and once it's used to unwrap the requests -- its never used again.  The charm unit keeps a hash around to compare against the token in the relation

1) vault issues an unwrap token
2) the charm reads at the token in the relation
3) the charm calculates a hash of the token
4) the charm compares the hash with its stored hash value (either lifted from reactive stored state or in the ops storedstate)
5) if the one-shot is different -- it will unwrap again to find it's new secret-id
6) after successfully unwrapping, the hash is stored only in the ops stored state. 

There's a small adjustment here to make sure the commit event actually updates the stored state.  I validated this was occurring by dumping the sqlite3 db on the unit once the units were active idle to confirm the hash and secret-id were correct. 