### PR TITLE
draft implementation

### DIFF
--- a/src/prometheus_alert_rules/kubernetesControlPlane-prometheusRule.yaml
+++ b/src/prometheus_alert_rules/kubernetesControlPlane-prometheusRule.yaml
@@ -11,7 +11,7 @@ groups:
       runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping
       summary: Pod is crash looping.
     expr: 'max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
-      job="kube-state-metrics"}[5m]) >= 1
+      job="kube-state-metrics", [[- namespace -]] }[5m]) >= 1
 
       '
     for: 15m


### PR DESCRIPTION
Includes hashing all alert rules files, copying them from prometheus_alert_rules to prometheus_alert_rules_parsed. When copying, replaces any templated varible in the [[- namespace -]] format. COSAgentProvider reads from the _parsed folder.