### PR TITLE
Strip the output from leader-get as it tends to add extra line feeds

### DIFF
--- a/src/leader_data.py
+++ b/src/leader_data.py
@@ -10,4 +10,4 @@ def set(key, value):
 
 def get(key):
     cmd = ["leader-get", key]
-    return check_output(cmd).decode()
+    return check_output(cmd).decode().strip()


### PR DESCRIPTION
[LP#2058269](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2058269)

This bug identified an upgrade issue where the cluster-name would have an extra line feed at its end.  We should be careful to strip any line endings


----------------
Original bug report:

It seems that the generated cluster name may contain and end-of-line character:
https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/blob/da2725c67c44bcc855de166fc3251c28879498dd/src/charm.py#L418C9-L418C28

Not sure how it could happen, but on grafana we can clearly see this:

          "labels": {
            "__name__": "kube_pod_container_resource_requests",
            "cluster": "kubernetes-1er8ci1qdkk64gndu4n0b8trf7azivp8\n",
            "container": "calico-node",
            "exported_node": "m2",
            "instance": "localhost:6443",
            "job": "kube-state-metrics",

Also see screenshot.

This can be confirmed by querying prometheus directly:

$ curl 10.1.199.215:9090/api/v1/label/cluster/values
{"status":"success","data":["etcd-0","kubernetes-1er8ci1qdkk64gndu4n0b8trf7azivp8\n"]}

