### PR TITLE
mock out charm reconciler while testing vault_kv module

### DIFF
--- a/tests/unit/test_vault_kv.py
+++ b/tests/unit/test_vault_kv.py
@@ -13,12 +13,13 @@ from encryption.vault_kv import VaultNotReadyError
 
 @pytest.fixture
 def harness():
-    harness = ops.testing.Harness(KubernetesControlPlaneCharm)
-    try:
-        harness.add_network("10.0.0.10", endpoint="vault-kv")
-        yield harness
-    finally:
-        harness.cleanup()
+    with mock.patch.object(KubernetesControlPlaneCharm, "reconcile"):
+        harness = ops.testing.Harness(KubernetesControlPlaneCharm)
+        try:
+            harness.add_network("10.0.0.10", endpoint="vault-kv")
+            yield harness
+        finally:
+            harness.cleanup()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
There's no reason for the charm reconciler method to be called while testing the vault_kv module

(found while unit testing in the release_1.29 branch -- which fails unit tests without this)