### PR TITLE
Partially support the keystone-credentials relation enough to uplift the keystone service

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -83,6 +83,13 @@ options:
     description: |
       Comma separated authorization modes. Allowed values are
       "RBAC", "Node", "Webhook", "ABAC", "AlwaysDeny" and "AlwaysAllow".
+  authorization-webhook-config-file:
+    type: string
+    default: ""
+    description: |
+      Authorization webhook config passed to kube-apiserver via --authorization-webhook-config-file.
+      For more info, please refer to the upstream documentation at
+      https://kubernetes.io/docs/reference/access-authn-authz/webhook/
   channel:
     type: string
     default: "latest/edge"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,6 +46,8 @@ requires:
     interface: gcp-integration
   azure:
     interface: azure-integration
+  keystone-credentials:
+    interface: keystone-credentials
   certificates:
     interface: tls-certificates
   dns-provider:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@main
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@main
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@main
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@KU-1000/support-authz-webhook
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@main
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@main
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@main
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@main
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@main
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@KU-1000/support-authz-webhook
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@main

--- a/src/auth_webhook.py
+++ b/src/auth_webhook.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import random
@@ -43,8 +42,8 @@ def _uplift_keystone_endpoint() -> str:
         keystone_auth_service = kubectl_get(
             "service", "-n", "kube-system", "k8s-keystone-auth-service", "--ignore-not-found=true"
         )
-    except json.JSONDecodeError:
-        log.info("No k8s-keystone-auth-service to uplift")
+    except (FileNotFoundError, CalledProcessError) as e:
+        log.info("No k8s-keystone-auth-service to uplift: error %s", e)
         return None
     labels = keystone_auth_service.get("metadata", {}).get("labels", {})
     if labels.get("cdk-addons") != "true":

--- a/src/auth_webhook.py
+++ b/src/auth_webhook.py
@@ -62,6 +62,7 @@ def _uplift_keystone_endpoint() -> str:
 
 
 def _uplift_aws_iam_endpoint() -> str:
+    log.warning("TODO: AWS IAM auth is not yet supported for uplift")
     return None
 
 

--- a/src/auth_webhook.py
+++ b/src/auth_webhook.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import random
@@ -40,9 +41,9 @@ def _uplift_keystone_endpoint() -> str:
     """Uplift the keystone auth service from a cdk-addons installation."""
     try:
         keystone_auth_service = kubectl_get(
-            "service", "-n", "kube-system", "k8s-keystone-auth-service"
+            "service", "-n", "kube-system", "k8s-keystone-auth-service", "--ignore-not-found=true"
         )
-    except CalledProcessError:
+    except json.JSONDecodeError:
         log.info("No k8s-keystone-auth-service to uplift")
         return None
     labels = keystone_auth_service.get("metadata", {}).get("labels", {})

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,6 @@ import auth_webhook
 import charms.contextual_status as status
 import leader_data
 import ops
-import tenacity
 import yaml
 from cdk_addons import CdkAddons
 from charms import kubernetes_snaps
@@ -321,7 +320,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             kubeconfig="/root/cdk/kubeschedulerconfig",
         )
 
-    @status.on_error(ops.WaitingStatus("Waiting for Auth Tokens"), tenacity.RetryError)
+    @status.on_error(ops.WaitingStatus("Waiting for Auth Tokens"), CalledProcessError)
     def create_kubeconfigs(self):
         status.add(ops.MaintenanceStatus("Creating kubeconfigs"))
         ca = self.certificates.ca
@@ -484,7 +483,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
                 log.info("COS token or cluster name not yet available.")
                 return []
             return self.cos_integration.get_metrics_endpoints(node_name, token, cluster_name)
-        except (CalledProcessError, tenacity.RetryError):
+        except CalledProcessError:
             log.info("Failed to retrieve COS token.")
             return []
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -150,6 +150,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             privileged=self.model.config["allow-privileged"],
             service_cidr=self.model.config["service-cidr"],
             external_cloud_provider=self.external_cloud_provider,
+            authz_webhook_conf_file=auth_webhook.authz_webhook_conf,
         )
 
     def configure_apiserver_kubelet_api_admin(self):
@@ -160,6 +161,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         auth_webhook.configure(
             charm_dir=self.charm_dir,
             custom_authn_endpoint=self.model.config["authn-webhook-endpoint"],
+            custom_authz_config_file=self.model.config["authorization-webhook-config-file"],
         )
 
     def warn_keystone_management(self):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import json
+from pathlib import Path
 from unittest.mock import call, patch
 
 import ops
@@ -145,7 +146,7 @@ def test_active(
     assert harness.model.unit.status == ActiveStatus("Ready")
 
     auth_webhook_configure.assert_called_once_with(
-        charm_dir=harness.charm.charm_dir, custom_authn_endpoint=""
+        charm_dir=harness.charm.charm_dir, custom_authn_endpoint="", custom_authz_config_file=""
     )
     configure_apiserver.assert_called_once_with(
         advertise_address="10.0.0.10",
@@ -159,6 +160,7 @@ def test_active(
         privileged="auto",
         service_cidr="10.152.183.0/24",
         external_cloud_provider=harness.charm.external_cloud_provider,
+        authz_webhook_conf_file=Path("/root/cdk/auth-webhook/authz-webhook-conf.yaml"),
     )
     configure_apiserver_kubelet_api_admin.assert_called_once_with()
     configure_controller_manager.assert_called_once_with(

--- a/tests/unit/test_kubectl.py
+++ b/tests/unit/test_kubectl.py
@@ -1,17 +1,69 @@
-from unittest.mock import patch
+import subprocess
+import unittest.mock as mock
 
 import kubectl
+import pytest
+import tenacity
 
 
-def test_kubectl():
+@pytest.fixture(params=["/root/.kube/config", "/home/ubuntu/config"])
+def kubeconfig(request):
+    with mock.patch("pathlib.Path.exists") as exists:
+        exists.return_value = True
+        yield request.param, (request.param == "/home/ubuntu/config")
+
+
+@mock.patch("pathlib.Path.exists")
+def test_kubectl_no_kubeconfig(exists):
+    """Verify kubectl fails immediately when there's no kubeconfig."""
+    exists.return_value = False
+    kubectl.kubectl.retry.wait = tenacity.wait_none()
+    kubectl.kubectl.retry.stop = tenacity.stop_after_attempt(3)
+    with pytest.raises(FileNotFoundError):
+        kubectl.kubectl("get", "svc", "my-service")
+
+
+@pytest.mark.usefixtures("kubeconfig")
+def test_kubectl_retried():
+    """Verify kubectl retries on failure."""
+    with mock.patch("kubectl.check_output") as check_output:
+        kubectl.kubectl.retry.wait = tenacity.wait_none()
+        kubectl.kubectl.retry.stop = tenacity.stop_after_attempt(3)
+        check_output.side_effect = subprocess.CalledProcessError(
+            1, "kubectl", b"stdout", b"stderr"
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            kubectl.kubectl("get", "svc", "my-service")
+        assert check_output.call_count == 3
+
+
+def test_kubectl_external(kubeconfig):
     """Verify kubectl uses the appropriate kubeconfig files."""
-    int_cfg = "--kubeconfig=/root/.kube/config"
-    ext_cfg = "--kubeconfig=/home/ubuntu/config"
+    path, external = kubeconfig
 
-    with patch("kubectl.check_output") as mock:
-        kubectl.kubectl()
-        assert int_cfg in mock.call_args.args[0]
+    with mock.patch("kubectl.check_output") as check_output:
+        kubectl.kubectl("apply", "-f", "test.yaml", external=external)
+        check_output.assert_called_once_with(
+            ["kubectl", f"--kubeconfig={path}", "apply", "-f", "test.yaml"]
+        )
 
-    with patch("kubectl.check_output") as mock:
-        kubectl.kubectl(external=True)
-        assert ext_cfg in mock.call_args.args[0]
+
+def test_kubectl_get():
+    """Verify kubectl_get parses kubectl results."""
+    with mock.patch("kubectl.kubectl") as m_kubectl:
+        m_kubectl.return_value = '{"kind": "Service", "metadata": {"name": "my-service"}}'
+        value = kubectl.kubectl_get("svc", "my-service")
+        m_kubectl.assert_called_once_with("get", "-o", "json", "svc", "my-service")
+        assert value == {"kind": "Service", "metadata": {"name": "my-service"}}
+
+        m_kubectl.return_value = ""
+        value = kubectl.kubectl_get("svc", "my-service")
+        assert value == {}
+
+
+def test_get_service_ip():
+    """Verify get_service_ip parses kubectl results."""
+    with mock.patch("kubectl.kubectl_get") as m_kubectl_get:
+        m_kubectl_get.return_value = {"kind": "Service", "spec": {"clusterIP": "1.2.3.4"}}
+        value = kubectl.get_service_ip("my-service", "my-namespace")
+        assert value == "1.2.3.4"


### PR DESCRIPTION
## Overview
Allows admins to upgrade to the 1.29/stable relation without actually managing the keystone-credentials relation. 
Will detect any existing keystone auth service that were deployed via previous installations

Dependent on 
* https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps/pull/18
* https://github.com/charmed-kubernetes/kubernetes-docs/pull/845

### Changes:
* reintroduces the keystone-credentials interface
* recognize a keystone-auth-service installed via cdk-addons and render its webhook url into  the auth_webhook.py
* provides juju admin ability to set `authorization-webhook-config-file`
* adjust `kubectl()` helper method to retry only when the command fails (not when kubeconfig file is missing)
* adjust `kubectl()` helper method to reraise the CalledProcessError rather than a tenacity.RetryError
* block the charm when the keystone-credentials interface is related -- don't manage it any longer
* test...test...test... kubectl module