### PR TITLE
[Cherry] Partially support the keystone-credentials relation enough to uplift the keystone service (#350)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -83,6 +83,13 @@ options:
     description: |
       Comma separated authorization modes. Allowed values are
       "RBAC", "Node", "Webhook", "ABAC", "AlwaysDeny" and "AlwaysAllow".
+  authorization-webhook-config-file:
+    type: string
+    default: ""
+    description: |
+      Authorization webhook config passed to kube-apiserver via --authorization-webhook-config-file.
+      For more info, please refer to the upstream documentation at
+      https://kubernetes.io/docs/reference/access-authn-authz/webhook/
   channel:
     type: string
     default: "1.29/stable"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -49,6 +49,8 @@ requires:
     interface: ceph-client
     description: |
       [Deprecated] LP:2048692 only necessary for upgrades from < 1.29
+  keystone-credentials:
+    interface: keystone-credentials
   certificates:
     interface: tls-certificates
   dns-provider:

--- a/src/auth_webhook.py
+++ b/src/auth_webhook.py
@@ -6,18 +6,20 @@ import re
 import string
 import tempfile
 from base64 import b64decode, b64encode
+from pathlib import Path
 from subprocess import CalledProcessError, check_call, check_output
 
 import charms.contextual_status as status
 import yaml
 from jinja2 import Environment, FileSystemLoader
-from kubectl import kubectl
+from kubectl import kubectl, kubectl_get
 from ops import MaintenanceStatus
 
 auth_secret_ns = "kube-system"
 auth_secret_type = "juju.is/token-auth"
 auth_webhook_root = "/root/cdk/auth-webhook"
 auth_webhook_conf = os.path.join(auth_webhook_root, "auth-webhook-conf.yaml")
+authz_webhook_conf = Path(auth_webhook_root) / "authz-webhook-conf.yaml"
 auth_webhook_exe = os.path.join(auth_webhook_root, "auth-webhook.py")
 # wokeignore:rule=master
 auth_webhook_svc_name = "cdk.master.auth-webhook"
@@ -27,11 +29,39 @@ log_dir = "/var/log/kubernetes"
 log = logging.getLogger(__name__)
 
 
-def configure(
-    charm_dir, aws_iam_endpoint=None, custom_authn_endpoint=None, keystone_endpoint=None
-):
+def _uplift_keystone_endpoint() -> str:
+    """Uplift the keystone auth service from a cdk-addons installation."""
+    try:
+        keystone_auth_service = kubectl_get(
+            "service", "-n", "kube-system", "k8s-keystone-auth-service", "--ignore-not-found=true"
+        )
+    except (FileNotFoundError, CalledProcessError) as e:
+        log.info("No k8s-keystone-auth-service to uplift: error %s", e)
+        return None
+    labels = keystone_auth_service.get("metadata", {}).get("labels", {})
+    if labels.get("cdk-addons") != "true":
+        log.info("No cdk-addons based k8s-keystone-auth-service to uplift")
+        return None
+    if not (spec := keystone_auth_service.get("spec")):
+        log.error("No spec found for k8s-keystone-auth-service")
+        return None
+    cluster_ip, port = spec.get("clusterIP"), spec.get("ports")[0].get("port")
+    if not cluster_ip or not port:
+        log.error("No clusterIP or port found for k8s-keystone-auth-service")
+        return None
+    return f"https://{cluster_ip}:{port}/webhook"
+
+
+def _uplift_aws_iam_endpoint() -> str:
+    log.warning("TODO: AWS IAM auth is not yet supported for uplift")
+    return None
+
+
+def configure(charm_dir, custom_authn_endpoint=None, custom_authz_config_file=None):
     """Render auth webhook templates and start the related service."""
     status.add(MaintenanceStatus("Configuring auth webhook"))
+    keystone_endpoint = _uplift_keystone_endpoint()
+    aws_iam_endpoint = _uplift_aws_iam_endpoint()
 
     # Set the number of gunicorn workers based on our core count. (2*cores)+1 is
     # recommended: https://docs.gunicorn.org/en/stable/design.html#how-many-workers
@@ -70,6 +100,8 @@ def configure(
     render("auth-webhook.logrotate", "/etc/logrotate.d/auth-webhook", context)
     render("auth-webhook.service", auth_webhook_svc, context)
     restart()
+
+    authz_webhook_conf.write_text(custom_authz_config_file or "")
 
 
 def create_token(uid, username, groups=[]):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,7 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import json
+from pathlib import Path
 from unittest.mock import call, patch
 
 import ops
@@ -145,7 +146,7 @@ def test_active(
     assert harness.model.unit.status == ActiveStatus()
 
     auth_webhook_configure.assert_called_once_with(
-        charm_dir=harness.charm.charm_dir, custom_authn_endpoint=""
+        charm_dir=harness.charm.charm_dir, custom_authn_endpoint="", custom_authz_config_file=""
     )
     configure_apiserver.assert_called_once_with(
         advertise_address="10.0.0.10",
@@ -159,6 +160,7 @@ def test_active(
         privileged="auto",
         service_cidr="10.152.183.0/24",
         external_cloud_provider=harness.charm.external_cloud_provider,
+        authz_webhook_conf_file=Path("/root/cdk/auth-webhook/authz-webhook-conf.yaml"),
     )
     configure_apiserver_kubelet_api_admin.assert_called_once_with()
     configure_controller_manager.assert_called_once_with(

--- a/tests/unit/test_kubectl.py
+++ b/tests/unit/test_kubectl.py
@@ -1,17 +1,69 @@
-from unittest.mock import patch
+import subprocess
+import unittest.mock as mock
 
 import kubectl
+import pytest
+import tenacity
 
 
-def test_kubectl():
+@pytest.fixture(params=["/root/.kube/config", "/home/ubuntu/config"])
+def kubeconfig(request):
+    with mock.patch("pathlib.Path.exists") as exists:
+        exists.return_value = True
+        yield request.param, (request.param == "/home/ubuntu/config")
+
+
+@mock.patch("pathlib.Path.exists")
+def test_kubectl_no_kubeconfig(exists):
+    """Verify kubectl fails immediately when there's no kubeconfig."""
+    exists.return_value = False
+    kubectl.kubectl.retry.wait = tenacity.wait_none()
+    kubectl.kubectl.retry.stop = tenacity.stop_after_attempt(3)
+    with pytest.raises(FileNotFoundError):
+        kubectl.kubectl("get", "svc", "my-service")
+
+
+@pytest.mark.usefixtures("kubeconfig")
+def test_kubectl_retried():
+    """Verify kubectl retries on failure."""
+    with mock.patch("kubectl.check_output") as check_output:
+        kubectl.kubectl.retry.wait = tenacity.wait_none()
+        kubectl.kubectl.retry.stop = tenacity.stop_after_attempt(3)
+        check_output.side_effect = subprocess.CalledProcessError(
+            1, "kubectl", b"stdout", b"stderr"
+        )
+        with pytest.raises(subprocess.CalledProcessError):
+            kubectl.kubectl("get", "svc", "my-service")
+        assert check_output.call_count == 3
+
+
+def test_kubectl_external(kubeconfig):
     """Verify kubectl uses the appropriate kubeconfig files."""
-    int_cfg = "--kubeconfig=/root/.kube/config"
-    ext_cfg = "--kubeconfig=/home/ubuntu/config"
+    path, external = kubeconfig
 
-    with patch("kubectl.check_output") as mock:
-        kubectl.kubectl()
-        assert int_cfg in mock.call_args.args[0]
+    with mock.patch("kubectl.check_output") as check_output:
+        kubectl.kubectl("apply", "-f", "test.yaml", external=external)
+        check_output.assert_called_once_with(
+            ["kubectl", f"--kubeconfig={path}", "apply", "-f", "test.yaml"]
+        )
 
-    with patch("kubectl.check_output") as mock:
-        kubectl.kubectl(external=True)
-        assert ext_cfg in mock.call_args.args[0]
+
+def test_kubectl_get():
+    """Verify kubectl_get parses kubectl results."""
+    with mock.patch("kubectl.kubectl") as m_kubectl:
+        m_kubectl.return_value = '{"kind": "Service", "metadata": {"name": "my-service"}}'
+        value = kubectl.kubectl_get("svc", "my-service")
+        m_kubectl.assert_called_once_with("get", "-o", "json", "svc", "my-service")
+        assert value == {"kind": "Service", "metadata": {"name": "my-service"}}
+
+        m_kubectl.return_value = ""
+        value = kubectl.kubectl_get("svc", "my-service")
+        assert value == {}
+
+
+def test_get_service_ip():
+    """Verify get_service_ip parses kubectl results."""
+    with mock.patch("kubectl.kubectl_get") as m_kubectl_get:
+        m_kubectl_get.return_value = {"kind": "Service", "spec": {"clusterIP": "1.2.3.4"}}
+        value = kubectl.get_service_ip("my-service", "my-namespace")
+        assert value == "1.2.3.4"


### PR DESCRIPTION
Cherry-pick to release 1.29 from https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/pull/350

* Partially support the keystone-credentials relation enough to uplift the keystone service
* Adjust the failure mode when there's no keystone-auth-service
* Improve kubectl() to error quicker when kubeconfig doesn't exist
* Juju admin can configure authorization-webhook-config-file
* charm-lib-kubernetes-snap back to main branch
* AWS IAM provides a warning
