### PR TITLE
Allow ceph-client to be related with a warning to no longer manage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ options:
       mode by default, unless certain circumstances are discovered
          * gpu hardware is detected on a worker node
          * openstack-integrator successfully related
-         * ceph-client successfully related
+
   api-extra-args:
     type: string
     default: ""

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -40,6 +40,9 @@ provides:
   tokens:
     interface: tokens
 requires:
+  ceph-client:
+    # Remains for upgrade compatibility with a warning to remove after upgrade
+    interface: ceph-client
   aws:
     interface: aws-integration
   gcp:
@@ -47,6 +50,7 @@ requires:
   azure:
     interface: azure-integration
   keystone-credentials:
+    # Remains for upgrade compatibility with a warning to remove after upgrade
     interface: keystone-credentials
   certificates:
     interface: tls-certificates

--- a/src/charm.py
+++ b/src/charm.py
@@ -175,6 +175,17 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             )
             status.add(ops.BlockedStatus("Keystone credential relation is no longer managed"))
 
+    def warn_ceph_client(self):
+        relation = self.model.relations.get("ceph-client")
+        if relation and any(r.units for r in relation):
+            log.warning(
+                "------------------------------------------------------------\n"
+                "Ceph-client relation is no longer managed\n"
+                "Please remove the relation and manage manually or with the ceph-csi charm\n"
+                "Run `juju remove-relation kubernetes-control-plane:ceph-csi ceph-mon`"
+            )
+            status.add(ops.BlockedStatus("Ceph-client relation is no longer managed"))
+
     @status.on_error(ops.WaitingStatus("Waiting for container runtime"))
     def configure_container_runtime(self):
         assert self.container_runtime.relations, "Missing container-runtime integration"
@@ -520,6 +531,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         self.write_service_account_key()
         self.configure_auth_webhook()
         self.warn_keystone_management()
+        self.warn_ceph_client()
         self.configure_loadbalancers()
         if self.api_dependencies_ready():
             self.encryption_at_rest.prepare()


### PR DESCRIPTION
## Overview
Allow  upgrading from 1.28 charms and prior while related over the `ceph-client` relation.  Will warn that ceph-client is a deprecated relation

## Details
The kubernetes-control-plane charm should no longer manage ceph workloads, (ceph xfs, ceph rdb, ceph-fs) which instead should be delegated to the [ceph-csi](charmhub.io/cephi-csi) charm.  For those upgrading from 1.28 when this relation existed, the existing workloads they are running deployed via the older versions of the charm will remain and be unmanaged by the charm.  Post upgrade, one can remove the relation and the charm will not disturb its deployment. 
