### PR TITLE
Update charm to update the root kubeconfig with a current CA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@main
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@main
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@main
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@bug/lp2064305/support-updating-kubeconfig
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@main
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@main
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@main
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@main
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@main
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@bug/lp2064305/support-updating-kubeconfig
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@main

--- a/src/cdk_addons.py
+++ b/src/cdk_addons.py
@@ -6,7 +6,7 @@ from subprocess import CalledProcessError, check_call, check_output
 
 import charms.contextual_status as status
 import tenacity
-from kubectl import get_service_ip, kubectl, kubectl_get
+from kubectl import ROOT_KUBECONFIG, get_service_ip, kubectl, kubectl_get
 from ops import BlockedStatus
 
 kubeconfig_dir = "/root/snap/cdk-addons/common"
@@ -88,7 +88,7 @@ class CdkAddons:
     def copy_kubeconfig(self):
         """Copy the admin kubeconfig to a location where cdk-addons can read it."""
         os.makedirs(kubeconfig_dir, exist_ok=True)
-        shutil.copy("/root/.kube/config", kubeconfig_path)
+        shutil.copy(ROOT_KUBECONFIG, kubeconfig_path)
 
     def get_default_storage_class(self):
         """Get the name of the default StorageClass."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,7 +41,7 @@ from encryption_at_rest import EncryptionAtRest
 from hacluster import HACluster
 from k8s_api_endpoints import K8sApiEndpoints
 from k8s_kube_system import get_kube_system_pods_not_running
-from kubectl import kubectl
+from kubectl import ROOT_KUBECONFIG, kubectl
 from loadbalancer_interface import LBProvider
 from ops.interface_kube_control import KubeControlProvides
 from ops.interface_tls_certificates import CertificatesRequires
@@ -80,7 +80,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             ],
         )
         self.etcd = EtcdReactiveRequires(self)
-        self.node_base = LabelMaker(self, kubeconfig_path="/root/.kube/config")
+        self.node_base = LabelMaker(self, kubeconfig_path=ROOT_KUBECONFIG)
         self.hacluster = HACluster(self, self.config)
         self.k8s_api_endpoints = K8sApiEndpoints(self)
         self.kube_control = KubeControlProvides(self, endpoint="kube-control")
@@ -186,7 +186,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
     def configure_cni(self):
         status.add(ops.MaintenanceStatus("Configuring CNI"))
         self.cni.set_image_registry(self.model.config["image-registry"])
-        self.cni.set_kubeconfig_hash_from_file("/root/.kube/config")
+        self.cni.set_kubeconfig_hash_from_file(ROOT_KUBECONFIG)
         self.cni.set_service_cidr(self.model.config["service-cidr"])
         kubernetes_snaps.set_default_cni_conf_file(self.cni.cni_conf_file)
 
@@ -330,26 +330,29 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         node_name = self.get_node_name()
         public_server = self.k8s_api_endpoints.external()
 
-        if not os.path.exists("/root/.kube/config"):
+        if not os.path.exists(ROOT_KUBECONFIG):
             # Create a bootstrap client config. This initial config will allow
             # us to get and create auth webhook tokens via the Kubernetes API,
             # but will not have the final admin token just yet.
-            kubernetes_snaps.create_kubeconfig(
-                "/root/.kube/config",
-                ca=ca,
-                server=local_server,
-                user="admin",
-                token=auth_webhook.token_generator(),
-            )
+            token = auth_webhook.token_generator()
+        else:
+            token = None
+
+        kubernetes_snaps.update_kubeconfig(
+            ROOT_KUBECONFIG,
+            ca=ca,
+            server=local_server,
+            token=token,
+            user="admin",
+        )
 
         admin_token = auth_webhook.create_token(
             uid="admin",
             username="admin",
-            # wokeignore:rule=master
-            groups=["system:masters"],
+            groups=["system:masters"],  # wokeignore:rule=master
         )
 
-        for dest in ["/root/.kube/config", "/home/ubuntu/.kube/config"]:
+        for dest in [ROOT_KUBECONFIG, "/home/ubuntu/.kube/config"]:
             kubernetes_snaps.create_kubeconfig(
                 dest,
                 ca=ca,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -35,7 +35,7 @@ def harness():
 @patch("charms.kubernetes_snaps.configure_kubelet")
 @patch("charms.kubernetes_snaps.configure_scheduler")
 @patch("charms.kubernetes_snaps.configure_services_restart_always")
-@patch("charms.kubernetes_snaps.create_kubeconfig")
+@patch("charms.kubernetes_snaps.update_kubeconfig")
 @patch("charms.kubernetes_snaps.get_public_address")
 @patch("charms.kubernetes_snaps.is_snap_installed")
 @patch("charms.kubernetes_snaps.install_snap")
@@ -65,7 +65,7 @@ def test_active(
     install_snap,
     is_snap_installed,
     get_public_address,
-    create_kubeconfig,
+    update_kubeconfig,
     configure_services_restart_always,
     configure_scheduler,
     configure_kubelet,
@@ -211,7 +211,7 @@ def test_active(
         extra_args_config="", kubeconfig="/root/cdk/kubeschedulerconfig"
     )
     configure_services_restart_always.assert_called_once_with(control_plane=True)
-    create_kubeconfig.assert_called()
+    update_kubeconfig.assert_called()
     install_snap.assert_called()
     install_cni_binaries.assert_called()
     set_default_cni_conf_file.assert_called_once_with("10-calico.conflist")

--- a/tests/unit/test_kubectl.py
+++ b/tests/unit/test_kubectl.py
@@ -44,7 +44,8 @@ def test_kubectl_external(kubeconfig):
     with mock.patch("kubectl.check_output") as check_output:
         kubectl.kubectl("apply", "-f", "test.yaml", external=external)
         check_output.assert_called_once_with(
-            ["kubectl", f"--kubeconfig={path}", "apply", "-f", "test.yaml"]
+            ["kubectl", f"--kubeconfig={path}", "apply", "-f", "test.yaml"],
+            stderr=subprocess.PIPE,
         )
 
 


### PR DESCRIPTION
## Overview
Each config hook should do it's best to update the root kubeconfig to have a valid ca cert.

## Details
According to the bug [LP#2064305][], the charm code couldn't connect to the control-plane because 

```
2024-04-27 06:14:19 WARNING unit.kubernetes-control-plane/1.certificates-relation-changed logger.go:60 Unable to connect to the server: tls: failed to verify certificate: x509: certificate signed by unknown authority
```

This can be caused by the CA being invalid on the next charm hook.  This PR addresses the issue by ensuring the CA cert is correct on each possible reconcile loop

Draft until the following is merged
* https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps/pull/21

<!-- Links -->
[LP#2064305]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/2064305