### PR TITLE
fix invalid dict merge in python3.8

### DIFF
--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -63,8 +63,9 @@ class CloudIntegration:
         status.add(ops.MaintenanceStatus(f"Integrate with {cloud_name}"))
         if cloud_name == "aws":
             aws_cluster_tag = {f"kubernetes.io/cluster/{cluster_tag}": "owned"}
+
             # wokeignore:rule=master
-            cloud.tag_instance(aws_cluster_tag | {"k8s.io/role/master": "true"})
+            cloud.tag_instance({**aws_cluster_tag, "k8s.io/role/master": "true"})
             cloud.tag_instance_security_group(aws_cluster_tag)
             cloud.tag_instance_subnet(aws_cluster_tag)
             cloud.enable_object_storage_management(["kubernetes-*"])


### PR DESCRIPTION
Cannot use the `|` to merge two dicts in python3.8 (focal).  Adjusting to a syntax which works in py3.8 and beyond