### PR TITLE
Add unit tests around cloud integration

### DIFF
--- a/src/cloud_integration.py
+++ b/src/cloud_integration.py
@@ -4,7 +4,7 @@
 """Cloud Integration for Charmed Kubernetes Control Plane."""
 
 import logging
-from typing import Union
+from typing import Optional, Union
 
 import charms.contextual_status as status
 import ops
@@ -13,6 +13,10 @@ from ops.interface_azure.requires import AzureIntegrationRequires
 from ops.interface_gcp.requires import GCPIntegrationRequires
 
 log = logging.getLogger(__name__)
+
+CloudSpecificIntegration = Union[
+    AWSIntegrationRequires, AzureIntegrationRequires, GCPIntegrationRequires
+]
 
 
 class CloudIntegration:
@@ -36,7 +40,7 @@ class CloudIntegration:
         self.azure = AzureIntegrationRequires(charm)
 
     @property
-    def cloud(self) -> Union[None, AWSIntegrationRequires, GCPIntegrationRequires]:
+    def cloud(self) -> Optional[CloudSpecificIntegration]:
         """Determine if we're integrated with a known cloud."""
         cloud_name = self.charm.get_cloud_name()
         cloud_support = {"aws": self.aws, "gce": self.gcp, "azure": self.azure}
@@ -55,7 +59,7 @@ class CloudIntegration:
     def integrate(self, event: ops.EventBase):
         """Request tags and permissions for a control-plane node."""
         if not (cloud := self.cloud):
-            return None
+            return
 
         cloud_name = self.charm.get_cloud_name()
         cluster_tag = self.charm.get_cluster_name()

--- a/tests/unit/test_cloud_integration.py
+++ b/tests/unit/test_cloud_integration.py
@@ -44,7 +44,10 @@ def test_cloud_aws(harness):
         event = mock.MagicMock()
         harness.charm.cloud_integration.integrate(event)
         mock_cloud.tag_instance.assert_called_once_with(
-            {"kubernetes.io/cluster/my-cluster": "owned", "k8s.io/role/master": "true"}
+            {
+                "kubernetes.io/cluster/my-cluster": "owned",
+                "k8s.io/role/master": "true",  # wokeignore:rule=master
+            }
         )
         mock_cloud.tag_instance_security_group.assert_called_once_with(
             {"kubernetes.io/cluster/my-cluster": "owned"}
@@ -74,7 +77,10 @@ def test_cloud_gce(harness):
         event = mock.MagicMock()
         harness.charm.cloud_integration.integrate(event)
         mock_cloud.tag_instance.assert_called_once_with(
-            {"k8s-io-cluster-name": "my-cluster", "k8s-io-role-master": "master"}
+            {
+                "k8s-io-cluster-name": "my-cluster",
+                "k8s-io-role-master": "master",  # wokeignore:rule=master
+            }
         )
         mock_cloud.enable_object_storage_management.assert_called_once()
         mock_cloud.enable_security_management.assert_called_once()
@@ -95,7 +101,10 @@ def test_cloud_azure(harness):
         event = mock.MagicMock()
         harness.charm.cloud_integration.integrate(event)
         mock_cloud.tag_instance.assert_called_once_with(
-            {"k8s-io-cluster-name": "my-cluster", "k8s-io-role-master": "master"}
+            {
+                "k8s-io-cluster-name": "my-cluster",
+                "k8s-io-role-master": "master",  # wokeignore:rule=master
+            }
         )
         mock_cloud.enable_object_storage_management.assert_called_once()
         mock_cloud.enable_security_management.assert_called_once()

--- a/tests/unit/test_cloud_integration.py
+++ b/tests/unit/test_cloud_integration.py
@@ -1,0 +1,119 @@
+import unittest.mock as mock
+
+import ops
+import pytest
+from charm import KubernetesControlPlaneCharm
+
+
+@pytest.fixture()
+def harness():
+    harness = ops.testing.Harness(KubernetesControlPlaneCharm)
+    harness.begin()
+    with mock.patch.object(harness.charm, "get_cloud_name"):
+        with mock.patch.object(harness.charm, "get_cluster_name", return_value="my-cluster"):
+            yield harness
+
+
+@pytest.mark.parametrize(
+    "cloud_name, cloud_relation",
+    [
+        ("aws", "aws"),
+        ("gce", "gcp"),
+        ("azure", "azure"),
+        ("unknown", None),
+    ],
+)
+def test_cloud_detection(harness, cloud_name, cloud_relation):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = cloud_name
+    integration = harness.charm.cloud_integration
+    assert integration.cloud is None
+    if cloud_name != "unknown":
+        harness.add_relation(cloud_relation, "cloud-integrator")
+        assert integration.cloud
+
+
+def test_cloud_aws(harness):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = "aws"
+    # with mock.patch.object(harness.charm.cloud_integration, "cloud", callable=mock.PropertyMock) as mock_cloud:
+    with mock.patch(
+        "cloud_integration.CloudIntegration.cloud", callable=mock.PropertyMock
+    ) as mock_cloud:
+        mock_cloud.evaluate_relation.return_value = None
+        event = mock.MagicMock()
+        harness.charm.cloud_integration.integrate(event)
+        mock_cloud.tag_instance.assert_called_once_with(
+            {"kubernetes.io/cluster/my-cluster": "owned", "k8s.io/role/master": "true"}
+        )
+        mock_cloud.tag_instance_security_group.assert_called_once_with(
+            {"kubernetes.io/cluster/my-cluster": "owned"}
+        )
+        mock_cloud.tag_instance_subnet.assert_called_once_with(
+            {"kubernetes.io/cluster/my-cluster": "owned"}
+        )
+        mock_cloud.enable_object_storage_management.assert_called_once_with(["kubernetes-*"])
+        mock_cloud.enable_load_balancer_management.assert_called_once()
+        mock_cloud.enable_autoscaling_readonly.assert_called_once()
+        mock_cloud.enable_instance_modification.assert_called_once()
+        mock_cloud.enable_region_readonly.assert_called_once()
+        mock_cloud.enable_instance_inspection.assert_called_once()
+        mock_cloud.enable_network_management.assert_called_once()
+        mock_cloud.enable_dns_management.assert_called_once()
+        mock_cloud.enable_block_storage_management.assert_called_once()
+        mock_cloud.evaluate_relation.assert_called_once_with(event)
+
+
+def test_cloud_gce(harness):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = "gce"
+    with mock.patch(
+        "cloud_integration.CloudIntegration.cloud", callable=mock.PropertyMock
+    ) as mock_cloud:
+        mock_cloud.evaluate_relation.return_value = None
+        event = mock.MagicMock()
+        harness.charm.cloud_integration.integrate(event)
+        mock_cloud.tag_instance.assert_called_once_with(
+            {"k8s-io-cluster-name": "my-cluster", "k8s-io-role-master": "master"}
+        )
+        mock_cloud.enable_object_storage_management.assert_called_once()
+        mock_cloud.enable_security_management.assert_called_once()
+        mock_cloud.enable_instance_inspection.assert_called_once()
+        mock_cloud.enable_network_management.assert_called_once()
+        mock_cloud.enable_dns_management.assert_called_once()
+        mock_cloud.enable_block_storage_management.assert_called_once()
+        mock_cloud.evaluate_relation.assert_called_once_with(event)
+
+
+def test_cloud_azure(harness):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = "azure"
+    with mock.patch(
+        "cloud_integration.CloudIntegration.cloud", callable=mock.PropertyMock
+    ) as mock_cloud:
+        mock_cloud.evaluate_relation.return_value = None
+        event = mock.MagicMock()
+        harness.charm.cloud_integration.integrate(event)
+        mock_cloud.tag_instance.assert_called_once_with(
+            {"k8s-io-cluster-name": "my-cluster", "k8s-io-role-master": "master"}
+        )
+        mock_cloud.enable_object_storage_management.assert_called_once()
+        mock_cloud.enable_security_management.assert_called_once()
+        mock_cloud.enable_loadbalancer_management.assert_called_once()
+        mock_cloud.enable_instance_inspection.assert_called_once()
+        mock_cloud.enable_network_management.assert_called_once()
+        mock_cloud.enable_dns_management.assert_called_once()
+        mock_cloud.enable_block_storage_management.assert_called_once()
+        mock_cloud.evaluate_relation.assert_called_once_with(event)
+
+
+def test_cloud_unknown(harness):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = "unknown"
+    with mock.patch(
+        "cloud_integration.CloudIntegration.cloud", new_callable=mock.PropertyMock
+    ) as mock_cloud:
+        mock_cloud.return_value = None
+        event = mock.MagicMock()
+        harness.charm.cloud_integration.integrate(event)
+        assert mock_cloud.called


### PR DESCRIPTION
## Overview

Adds unit testing to cloud_integration.py 

## Details
It was spotted in SolQA that our cloud integration with AWS failed in focal because of an unsupported dict augmentation introduced in python3.9.  Our validation testing of integration was only running on jammy and didn't spot this.  Had we had good unit tests on this module, we'd have spotted this early in CI.

Finally adding good unit testing here so we spot these things early rather than late