### PR TITLE
Carefully use a status context on actions

### DIFF
--- a/src/actions/general.py
+++ b/src/actions/general.py
@@ -4,6 +4,7 @@ import subprocess
 import tempfile
 
 import ops
+
 from kubectl import kubectl
 
 

--- a/src/actions/namespace.py
+++ b/src/actions/namespace.py
@@ -2,8 +2,9 @@ import os
 import tempfile
 
 import ops
-from kubectl import kubectl
 from yaml import safe_dump, safe_load
+
+from kubectl import kubectl
 
 os.environ["PATH"] += os.pathsep + os.path.join(os.sep, "snap", "bin")
 

--- a/src/actions/restart.py
+++ b/src/actions/restart.py
@@ -1,14 +1,18 @@
-import charms.contextual_status as status
 import ops
 from charms import kubernetes_snaps
+
+SERVICES = {
+    "api-server": "snap.kube-apiserver.daemon",
+    "controller-manager": "snap.kube-controller-manager.daemon",
+    "kube-scheduler": "snap.kube-scheduler.daemon",
+}
 
 
 def restart_action(event: ops.ActionEvent):
     """Handle the upgrade action."""
-    with status.context(event.framework.model.unit):
-        kubernetes_snaps.service_restart("snap.kube-apiserver.daemon")
-        event.set_results({"api-server": {"status": "restarted"}})
-        kubernetes_snaps.service_restart("snap.kube-controller-manager.daemon")
-        event.set_results({"controller-manager": {"status": "restarted"}})
-        kubernetes_snaps.service_restart("snap.kube-scheduler.daemon")
-        event.set_results({"kube-scheduler": {"status": "restarted"}})
+    try:
+        for service, snap in SERVICES.items():
+            kubernetes_snaps.service_restart(snap)
+            event.set_results({service: {"status": "restarted"}})
+    except Exception as e:
+        event.fail(str(e))

--- a/src/actions/upgrade.py
+++ b/src/actions/upgrade.py
@@ -1,3 +1,4 @@
+import charms.contextual_status as status
 import ops
 from charms import kubernetes_snaps
 
@@ -5,11 +6,8 @@ from charms import kubernetes_snaps
 def upgrade_action(charm, event: ops.ActionEvent):
     """Handle the upgrade action."""
     channel = event.framework.model.config.get("channel")
-    try:
+    with status.context(charm.unit):
         kubernetes_snaps.upgrade_snaps(channel=channel, event=event, control_plane=True)
-    except Exception as e:
-        event.fail(str(e))
-        return
-
-    # Post successful upgrade, reconcile the charm to ensure it is in the desired state
-    charm.reconciler.reconcile(event)
+    if isinstance(charm.unit.status, ops.ActiveStatus):
+        # After successful upgrade, reconcile the charm to ensure it is in the desired state
+        charm.reconciler.reconcile(event)

--- a/src/actions/upgrade.py
+++ b/src/actions/upgrade.py
@@ -1,10 +1,15 @@
-import charms.contextual_status as status
 import ops
 from charms import kubernetes_snaps
 
 
-def upgrade_action(event: ops.ActionEvent):
+def upgrade_action(charm, event: ops.ActionEvent):
     """Handle the upgrade action."""
-    with status.context(event.framework.model.unit):
-        channel = event.framework.model.config.get("channel")
+    channel = event.framework.model.config.get("channel")
+    try:
         kubernetes_snaps.upgrade_snaps(channel=channel, event=event, control_plane=True)
+    except Exception as e:
+        event.fail(str(e))
+        return
+
+    # Post successful upgrade, reconcile the charm to ensure it is in the desired state
+    charm.reconciler.reconcile(event)

--- a/src/actions/users.py
+++ b/src/actions/users.py
@@ -3,8 +3,9 @@ import os
 import re
 
 import ops
-from auth_webhook import create_token, delete_token, get_secrets
 from charms import kubernetes_snaps
+
+from auth_webhook import create_token, delete_token, get_secrets
 
 
 def protect_resources(name: str, event: ops.ActionEvent) -> bool:

--- a/src/auth_webhook.py
+++ b/src/auth_webhook.py
@@ -13,8 +13,9 @@ from typing import Mapping
 import charms.contextual_status as status
 import yaml
 from jinja2 import Environment, FileSystemLoader
-from kubectl import kubectl, kubectl_get
 from ops import MaintenanceStatus
+
+from kubectl import kubectl, kubectl_get
 
 auth_secret_ns = "kube-system"
 auth_secret_type = "juju.is/token-auth"

--- a/src/cdk_addons.py
+++ b/src/cdk_addons.py
@@ -6,8 +6,9 @@ from subprocess import CalledProcessError, check_call, check_output
 
 import charms.contextual_status as status
 import tenacity
-from kubectl import ROOT_KUBECONFIG, get_service_ip, kubectl, kubectl_get
 from ops import BlockedStatus
+
+from kubectl import ROOT_KUBECONFIG, get_service_ip, kubectl, kubectl_get
 
 kubeconfig_dir = "/root/snap/cdk-addons/common"
 kubeconfig_path = f"{kubeconfig_dir}/kubeconfig"

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ from typing import Callable
 
 import actions.general
 import actions.namespace
+import actions.restart
 import actions.upgrade
 import actions.users
 import auth_webhook
@@ -132,6 +133,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
 
         # register charm actions
         actions = [
+            self.on.restart_action,
             self.on.upgrade_action,
             self.on.get_kubeconfig_action,
             self.on.apply_manifest_action,
@@ -150,7 +152,8 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
 
     def charm_actions(self, event: ops.ActionEvent):
         action_map = {
-            "upgrade_action": actions.upgrade.upgrade_action,
+            "restart_action": actions.restart.restart_action,
+            "upgrade_action": functools.partial(actions.upgrade.upgrade_action, self),
             "get_kubeconfig_action": actions.general.get_kubeconfig,
             "apply_manifest_action": actions.general.apply_manifest,
             "user_create_action": functools.partial(actions.users.user_create, self),

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,17 +15,9 @@ from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Callable
 
-import actions.general
-import actions.namespace
-import actions.restart
-import actions.upgrade
-import actions.users
-import auth_webhook
 import charms.contextual_status as status
-import leader_data
 import ops
 import yaml
-from cdk_addons import CdkAddons
 from charms import kubernetes_snaps
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from charms.interface_container_runtime import ContainerRuntimeProvides
@@ -36,6 +28,18 @@ from charms.interface_tokens import TokensProvider
 from charms.kubernetes_libs.v0.etcd import EtcdReactiveRequires
 from charms.node_base import LabelMaker
 from charms.reconciler import Reconciler
+from loadbalancer_interface import LBProvider
+from ops.interface_kube_control import KubeControlProvides
+from ops.interface_tls_certificates import CertificatesRequires
+
+import actions.general
+import actions.namespace
+import actions.restart
+import actions.upgrade
+import actions.users
+import auth_webhook
+import leader_data
+from cdk_addons import CdkAddons
 from cloud_integration import CloudIntegration
 from cos_integration import COSIntegration
 from encryption_at_rest import EncryptionAtRest
@@ -43,9 +47,6 @@ from hacluster import HACluster
 from k8s_api_endpoints import K8sApiEndpoints
 from k8s_kube_system import get_kube_system_pods_not_running
 from kubectl import ROOT_KUBECONFIG, kubectl
-from loadbalancer_interface import LBProvider
-from ops.interface_kube_control import KubeControlProvides
-from ops.interface_tls_certificates import CertificatesRequires
 
 log = logging.getLogger(__name__)
 

--- a/src/encryption/vault_kv.py
+++ b/src/encryption/vault_kv.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 import hvac
 import ops
 import requests
+
 from encryption import reactive
 
 log = logging.getLogger(__name__)

--- a/src/encryption/vaultlocker.py
+++ b/src/encryption/vaultlocker.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import charms.operator_libs_linux.v0.apt as apt
 import ops
+
 from encryption.fstab import Fstab
 from encryption.vault_kv import VaultKV, VaultNotReadyError
 

--- a/src/encryption_at_rest.py
+++ b/src/encryption_at_rest.py
@@ -6,8 +6,9 @@ from typing import Mapping, Optional
 import charms.contextual_status as status
 import ops
 import yaml
-from auth_webhook import token_generator
 from charms import kubernetes_snaps
+
+from auth_webhook import token_generator
 from encryption.vault_kv import VaultKV, VaultNotReadyError
 from encryption.vaultlocker import VaultLocker, VaultLockerError
 

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,10 +1,11 @@
 from unittest import mock
 
-import actions.restart
-import actions.upgrade
 import charms.contextual_status as status
 import ops
 import pytest
+
+import actions.restart
+import actions.upgrade
 from charm import KubernetesControlPlaneCharm
 
 

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,0 +1,77 @@
+from unittest import mock
+
+import actions.restart
+import actions.upgrade
+import charms.contextual_status as status
+import ops
+import pytest
+from charm import KubernetesControlPlaneCharm
+
+
+@pytest.fixture
+def harness():
+    harness = ops.testing.Harness(KubernetesControlPlaneCharm)
+    try:
+        harness.begin_with_initial_hooks()
+        yield harness
+    finally:
+        harness.cleanup()
+
+
+@mock.patch.object(actions.upgrade.kubernetes_snaps, "upgrade_snaps")
+def test_upgrade_action_success(upgrade_snaps: mock.Mock, harness):
+    """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
+
+    def mock_reconciler(_):
+        status.add(ops.BlockedStatus("reconciled"))
+
+    harness.model.unit.status = ops.model.BlockedStatus("pre-test")
+    with mock.patch.object(
+        harness.charm.reconciler, "reconcile_function", side_effect=mock_reconciler
+    ) as mocked_reconciler:
+        harness.run_action("upgrade")
+    upgrade_snaps.assert_called_once()
+    mocked_reconciler.assert_called_once()
+    assert harness.model.unit.status == ops.BlockedStatus("reconciled")
+
+
+@mock.patch.object(
+    actions.upgrade.kubernetes_snaps, "upgrade_snaps", side_effect=Exception("snap upgrade failed")
+)
+def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
+    """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
+    harness.model.unit.status = ops.model.BlockedStatus("pre-test")
+    with mock.patch.object(harness.charm.reconciler, "reconcile_function") as mocked_reconciler:
+        with pytest.raises(ops.testing.ActionFailed) as action_err:
+            harness.run_action("upgrade")
+    upgrade_snaps.assert_called_once()
+    mocked_reconciler.assert_not_called()
+    assert action_err.value.message == "snap upgrade failed"
+    assert harness.model.unit.status == ops.BlockedStatus("pre-test")
+
+
+@mock.patch.object(actions.restart.kubernetes_snaps, "service_restart")
+def test_restart_action_success(service_restart: mock.Mock, harness):
+    """Verify that the restart action runs the service_restart method."""
+    harness.run_action("restart")
+    service_restart.assert_has_calls(
+        [
+            mock.call("snap.kube-apiserver.daemon"),
+            mock.call("snap.kube-controller-manager.daemon"),
+            mock.call("snap.kube-scheduler.daemon"),
+        ]
+    )
+
+
+@mock.patch.object(
+    actions.restart.kubernetes_snaps,
+    "service_restart",
+    side_effect=Exception("snap restart failed"),
+)
+def test_restart_action_fails(service_restart: mock.Mock, harness):
+    """Verify that the restart action fails the service_restart method."""
+    with pytest.raises(ops.testing.ActionFailed) as action_err:
+        harness.run_action("restart")
+
+    service_restart.assert_called_once_with("snap.kube-apiserver.daemon")
+    assert action_err.value.message == "snap restart failed"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,8 +10,9 @@ from unittest.mock import call, patch
 import ops
 import ops.testing
 import pytest
-from charm import KubernetesControlPlaneCharm
 from ops import ActiveStatus
+
+from charm import KubernetesControlPlaneCharm
 
 
 @pytest.fixture

--- a/tests/unit/test_cloud_integration.py
+++ b/tests/unit/test_cloud_integration.py
@@ -2,6 +2,7 @@ import unittest.mock as mock
 
 import ops
 import pytest
+
 from charm import KubernetesControlPlaneCharm
 
 

--- a/tests/unit/test_kubectl.py
+++ b/tests/unit/test_kubectl.py
@@ -1,9 +1,10 @@
 import subprocess
 import unittest.mock as mock
 
-import kubectl
 import pytest
 import tenacity
+
+import kubectl
 
 
 @pytest.fixture(params=["/root/.kube/config", "/home/ubuntu/config"])

--- a/tests/unit/test_vault_kv.py
+++ b/tests/unit/test_vault_kv.py
@@ -6,6 +6,7 @@ import hvac.exceptions
 import ops
 import ops.testing
 import pytest
+
 from charm import KubernetesControlPlaneCharm
 from encryption.reactive import retrieve_secret_id
 from encryption.vault_kv import VaultNotReadyError

--- a/tests/unit/test_vaultlocker.py
+++ b/tests/unit/test_vaultlocker.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 from unittest import mock
 
-import encryption.vaultlocker
 import ops
 import ops.testing
 import pytest
+
+import encryption.vaultlocker
 from charm import KubernetesControlPlaneCharm
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,18 +27,16 @@ pass_env =
 [testenv:format]
 description = Apply coding style standards to code
 deps =
-    black
     ruff
 commands =
-    black {[vars]all_path}
     ruff format {[vars]all_path}
     ruff check --fix --select I {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
     ruff
+    tomli
     codespell
 commands =
     # if this charm owns a lib, uncomment "lib_path" variable
@@ -46,7 +44,6 @@ commands =
     # codespell {[vars]lib_path}
     codespell {tox_root}
     ruff check {[vars]all_path}
-    black --check --diff {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
### Overview
Addresses [LP#2077189](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2077189)

Charm actions shouldn't use `status.context` because all that happens is that it ignores all exceptions and sets the unit status to Active/Idle

But the `upgrade` action has to use it since `kubernetes_snaps` depends on using the `status.add` method, so we have to carefully manage it

### Details
* A bunch of files are touched b/c `ruff` wants to test things harder.  
* The LP bug was discovered by @pedrofragola -- thanks so much
* But it turns out that using the `status.context` wipes out the charm's unit.status
   *  if `status.context` is used outside of a reconciled action, then we must run the reconciler again
   * MOST IMPORTANTLY -- we don't need WIPE out a WaitingStatus or BlockedStatus just because we ran an action. That's kinda bonkers
