### PR TITLE
Mark the unit as waiting when kube-system pods aren't ready

### DIFF
--- a/src/k8s_kube_system.py
+++ b/src/k8s_kube_system.py
@@ -54,9 +54,9 @@ def get_kube_system_pods_not_running(charm) -> Optional[List]:
     # Pods that are Running or Evicted (which should re-spawn) are
     # considered running
     def is_ready(pod):
-        container_stati = pod["status"].get("initContainerStatuses", [])
-        container_stati += pod["status"].get("containerStatuses", [])
-        return all(status.get("ready", True) for status in container_stati)
+        container_statuses = pod["status"].get("initContainerStatuses", [])
+        container_statuses += pod["status"].get("containerStatuses", [])
+        return all(status.get("ready", True) for status in container_statuses)
 
     def is_invalid(pod):
         status = pod["status"]

--- a/tests/data/kube-system-pods.yaml
+++ b/tests/data/kube-system-pods.yaml
@@ -1,0 +1,6345 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "juju.is/manifest-hash": "c66a480b7e55014bf9672cf16d291e26abd9d48f9a480dc66f6d2d9a3c5d9dcd"
+                },
+                "creationTimestamp": "2024-08-26T17:42:35Z",
+                "generateName": "cilium-",
+                "labels": {
+                    "app.kubernetes.io/name": "cilium-agent",
+                    "app.kubernetes.io/part-of": "cilium",
+                    "controller-revision-hash": "644fc947f8",
+                    "k8s-app": "cilium",
+                    "pod-template-generation": "5"
+                },
+                "name": "cilium-7qfz6",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "DaemonSet",
+                        "name": "cilium",
+                        "uid": "6a7d5dc2-66ea-433d-a3c7-324dc0b55c87"
+                    }
+                ],
+                "resourceVersion": "2892",
+                "uid": "89453a48-918d-4758-a009-b9672b019f5f"
+            },
+            "spec": {
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchFields": [
+                                        {
+                                            "key": "metadata.name",
+                                            "operator": "In",
+                                            "values": [
+                                                "juju-98a2d4-9"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "podAntiAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "k8s-app": "cilium"
+                                    }
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": true,
+                "containers": [
+                    {
+                        "args": [
+                            "--config-dir=/tmp/cilium/config-map"
+                        ],
+                        "command": [
+                            "cilium-agent"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_CLUSTERMESH_CONFIG",
+                                "value": "/var/lib/cilium/clustermesh/"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "lifecycle": {
+                            "postStart": {
+                                "exec": {
+                                    "command": [
+                                        "bash",
+                                        "-c",
+                                        "set -o errexit\nset -o pipefail\nset -o nounset\n\n# When running in AWS ENI mode, it's likely that 'aws-node' has\n# had a chance to install SNAT iptables rules. These can result\n# in dropped traffic, so we should attempt to remove them.\n# We do it using a 'postStart' hook since this may need to run\n# for nodes which might have already been init'ed but may still\n# have dangling rules. This is safe because there are no\n# dependencies on anything that is part of the startup script\n# itself, and can be safely run multiple times per node (e.g. in\n# case of a restart).\nif [[ \"$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')\" != \"0\" ]];\nthen\n    echo 'Deleting iptables rules created by the AWS CNI VPC plugin'\n    iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore\nfi\necho 'Done!'\n"
+                                    ]
+                                }
+                            },
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "/cni-uninstall.sh"
+                                    ]
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "cilium-agent",
+                        "ports": [
+                            {
+                                "containerPort": 4244,
+                                "hostPort": 4244,
+                                "name": "peer-service",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9962,
+                                "hostPort": 9962,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9964,
+                                "hostPort": 9964,
+                                "name": "envoy-metrics",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9965,
+                                "hostPort": 9965,
+                                "name": "hubble-metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "startupProbe": {
+                            "failureThreshold": 105,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 2,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "mountPropagation": "Bidirectional",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "hostNetwork": true,
+                "initContainers": [
+                    {
+                        "command": [
+                            "cilium",
+                            "build-config"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "config",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-mount /hostbin/cilium-mount;\nnsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-mount\" $CGROUP_ROOT;\nrm /hostbin/cilium-mount\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "CGROUP_ROOT",
+                                "value": "/run/cilium/cgroupv2"
+                            },
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "mount-cgroup",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;\nnsenter --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-sysctlfix\";\nrm /hostbin/cilium-sysctlfix\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "apply-sysctl-overwrites",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/init-container.sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "CILIUM_ALL_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_BPF_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-bpf-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "clean-cilium-state",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "mountPropagation": "HostToContainer",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/install-plugin.sh"
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "install-cni-binaries",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "10Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "nodeName": "juju-98a2d4-9",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000001000,
+                "priorityClassName": "system-node-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "cilium",
+                "serviceAccountName": "cilium",
+                "terminationGracePeriodSeconds": 1,
+                "tolerations": [
+                    {
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/pid-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/unschedulable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/network-unavailable",
+                        "operator": "Exists"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "emptyDir": {},
+                        "name": "tmp"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/run/cilium",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-run"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/sys/fs/bpf",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "bpf-maps"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/proc",
+                            "type": "Directory"
+                        },
+                        "name": "hostproc"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/cilium/cgroupv2",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-cgroup"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/opt/cni/bin",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cni-path"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/etc/cni/net.d",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "etc-cni-netd"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/lib/modules",
+                            "type": ""
+                        },
+                        "name": "lib-modules"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/xtables.lock",
+                            "type": "FileOrCreate"
+                        },
+                        "name": "xtables-lock"
+                    },
+                    {
+                        "name": "clustermesh-secrets",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "name": "cilium-clustermesh",
+                                        "optional": true
+                                    }
+                                },
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.key",
+                                                "path": "common-etcd-client.key"
+                                            },
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "common-etcd-client.crt"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "common-etcd-client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "clustermesh-apiserver-remote-cert",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "hubble-tls",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "server.crt"
+                                            },
+                                            {
+                                                "key": "tls.key",
+                                                "path": "server.key"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "hubble-server-certs",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "kube-api-access-wk7fj",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:43:13Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:43:42Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:43:48Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:43:48Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:35Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://4ecfb8bdb8fda2e0594ee033ccf91f36b7340ba7d391dfe28427345905e9d07b",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "cilium-agent",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T17:43:43Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.220",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.220"
+                    }
+                ],
+                "initContainerStatuses": [
+                    {
+                        "containerID": "containerd://2acec06e76ed41286568022e30ebac9b63095776bbbcb5e3ae7eab063902ba9c",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "config",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://2acec06e76ed41286568022e30ebac9b63095776bbbcb5e3ae7eab063902ba9c",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:43:36Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:43:36Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://7ec7fe94bffae456067c5788e5823b6b0b5613dec01134ef4b47122e40f1995f",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "mount-cgroup",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://7ec7fe94bffae456067c5788e5823b6b0b5613dec01134ef4b47122e40f1995f",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:43:39Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:43:39Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://9b5467f3d3c2aec73c2706536babf079fe262d8944a349fe25061fe274ec4ef2",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "apply-sysctl-overwrites",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://9b5467f3d3c2aec73c2706536babf079fe262d8944a349fe25061fe274ec4ef2",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:43:40Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:43:40Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://bb29fa500b5e552b853685d2d45e1c48784b1b528d04821f4cd8bffaf585736c",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "clean-cilium-state",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://bb29fa500b5e552b853685d2d45e1c48784b1b528d04821f4cd8bffaf585736c",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:43:41Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:43:41Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://b5407eecd9cb090e34aefaf17a20123a65694c34ab6e6e050af7e26164e554a7",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "install-cni-binaries",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://b5407eecd9cb090e34aefaf17a20123a65694c34ab6e6e050af7e26164e554a7",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:43:42Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:43:42Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wk7fj",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.246.154.220",
+                "podIPs": [
+                    {
+                        "ip": "10.246.154.220"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2024-08-26T17:43:13Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "juju.is/manifest-hash": "c66a480b7e55014bf9672cf16d291e26abd9d48f9a480dc66f6d2d9a3c5d9dcd"
+                },
+                "creationTimestamp": "2024-08-26T17:42:03Z",
+                "generateName": "cilium-",
+                "labels": {
+                    "app.kubernetes.io/name": "cilium-agent",
+                    "app.kubernetes.io/part-of": "cilium",
+                    "controller-revision-hash": "644fc947f8",
+                    "k8s-app": "cilium",
+                    "pod-template-generation": "5"
+                },
+                "name": "cilium-9b7d6",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "DaemonSet",
+                        "name": "cilium",
+                        "uid": "6a7d5dc2-66ea-433d-a3c7-324dc0b55c87"
+                    }
+                ],
+                "resourceVersion": "2268",
+                "uid": "56f895d1-9489-4c4d-ac30-879db6ec66bb"
+            },
+            "spec": {
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchFields": [
+                                        {
+                                            "key": "metadata.name",
+                                            "operator": "In",
+                                            "values": [
+                                                "juju-98a2d4-6"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "podAntiAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "k8s-app": "cilium"
+                                    }
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": true,
+                "containers": [
+                    {
+                        "args": [
+                            "--config-dir=/tmp/cilium/config-map"
+                        ],
+                        "command": [
+                            "cilium-agent"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_CLUSTERMESH_CONFIG",
+                                "value": "/var/lib/cilium/clustermesh/"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "lifecycle": {
+                            "postStart": {
+                                "exec": {
+                                    "command": [
+                                        "bash",
+                                        "-c",
+                                        "set -o errexit\nset -o pipefail\nset -o nounset\n\n# When running in AWS ENI mode, it's likely that 'aws-node' has\n# had a chance to install SNAT iptables rules. These can result\n# in dropped traffic, so we should attempt to remove them.\n# We do it using a 'postStart' hook since this may need to run\n# for nodes which might have already been init'ed but may still\n# have dangling rules. This is safe because there are no\n# dependencies on anything that is part of the startup script\n# itself, and can be safely run multiple times per node (e.g. in\n# case of a restart).\nif [[ \"$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')\" != \"0\" ]];\nthen\n    echo 'Deleting iptables rules created by the AWS CNI VPC plugin'\n    iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore\nfi\necho 'Done!'\n"
+                                    ]
+                                }
+                            },
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "/cni-uninstall.sh"
+                                    ]
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "cilium-agent",
+                        "ports": [
+                            {
+                                "containerPort": 4244,
+                                "hostPort": 4244,
+                                "name": "peer-service",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9962,
+                                "hostPort": 9962,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9964,
+                                "hostPort": 9964,
+                                "name": "envoy-metrics",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9965,
+                                "hostPort": 9965,
+                                "name": "hubble-metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "startupProbe": {
+                            "failureThreshold": 105,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 2,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "mountPropagation": "Bidirectional",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "hostNetwork": true,
+                "initContainers": [
+                    {
+                        "command": [
+                            "cilium",
+                            "build-config"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "config",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-mount /hostbin/cilium-mount;\nnsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-mount\" $CGROUP_ROOT;\nrm /hostbin/cilium-mount\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "CGROUP_ROOT",
+                                "value": "/run/cilium/cgroupv2"
+                            },
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "mount-cgroup",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;\nnsenter --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-sysctlfix\";\nrm /hostbin/cilium-sysctlfix\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "apply-sysctl-overwrites",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/init-container.sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "CILIUM_ALL_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_BPF_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-bpf-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "clean-cilium-state",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "mountPropagation": "HostToContainer",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/install-plugin.sh"
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "install-cni-binaries",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "10Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "nodeName": "juju-98a2d4-6",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000001000,
+                "priorityClassName": "system-node-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "cilium",
+                "serviceAccountName": "cilium",
+                "terminationGracePeriodSeconds": 1,
+                "tolerations": [
+                    {
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/pid-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/unschedulable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/network-unavailable",
+                        "operator": "Exists"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "emptyDir": {},
+                        "name": "tmp"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/run/cilium",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-run"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/sys/fs/bpf",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "bpf-maps"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/proc",
+                            "type": "Directory"
+                        },
+                        "name": "hostproc"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/cilium/cgroupv2",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-cgroup"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/opt/cni/bin",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cni-path"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/etc/cni/net.d",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "etc-cni-netd"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/lib/modules",
+                            "type": ""
+                        },
+                        "name": "lib-modules"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/xtables.lock",
+                            "type": "FileOrCreate"
+                        },
+                        "name": "xtables-lock"
+                    },
+                    {
+                        "name": "clustermesh-secrets",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "name": "cilium-clustermesh",
+                                        "optional": true
+                                    }
+                                },
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.key",
+                                                "path": "common-etcd-client.key"
+                                            },
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "common-etcd-client.crt"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "common-etcd-client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "clustermesh-apiserver-remote-cert",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "hubble-tls",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "server.crt"
+                                            },
+                                            {
+                                                "key": "tls.key",
+                                                "path": "server.key"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "hubble-server-certs",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "kube-api-access-kvc2x",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:04Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:08Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:13Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:13Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:03Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://c5b75f8e375c6120f795b53658fb6d1c2e302dd3b6499575e6b847af3773dae0",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "cilium-agent",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T17:42:08Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.197",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.197"
+                    }
+                ],
+                "initContainerStatuses": [
+                    {
+                        "containerID": "containerd://6e4d7d5364d0413f01799574e7cf3ba8178dc05ba122d5427bb95c0718dfa83e",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "config",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://6e4d7d5364d0413f01799574e7cf3ba8178dc05ba122d5427bb95c0718dfa83e",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:03Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:03Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://9d3340bf2575cabd05e6db40819e50c1f285e8e0050fcfe313adbf3d14ee4027",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "mount-cgroup",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://9d3340bf2575cabd05e6db40819e50c1f285e8e0050fcfe313adbf3d14ee4027",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:04Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:04Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://c2f105d2a4eb7346a9895547e4ad93284cba989884829c9a73050af84d04302a",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "apply-sysctl-overwrites",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://c2f105d2a4eb7346a9895547e4ad93284cba989884829c9a73050af84d04302a",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:05Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:05Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://6063eee971a6de79671eb247dd10bc67c17091bbdb062edf6c8bb2f90e6afb7c",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "clean-cilium-state",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://6063eee971a6de79671eb247dd10bc67c17091bbdb062edf6c8bb2f90e6afb7c",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:06Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:06Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://15cf8041b6e56f76ab93bcf249f51fd42935e7a240ec14d42ff8f385b5eaaa63",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "install-cni-binaries",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://15cf8041b6e56f76ab93bcf249f51fd42935e7a240ec14d42ff8f385b5eaaa63",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:07Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:07Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-kvc2x",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.246.154.197",
+                "podIPs": [
+                    {
+                        "ip": "10.246.154.197"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2024-08-26T17:42:03Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "juju.is/manifest-hash": "c66a480b7e55014bf9672cf16d291e26abd9d48f9a480dc66f6d2d9a3c5d9dcd"
+                },
+                "creationTimestamp": "2024-08-26T17:41:23Z",
+                "generateName": "cilium-",
+                "labels": {
+                    "app.kubernetes.io/name": "cilium-agent",
+                    "app.kubernetes.io/part-of": "cilium",
+                    "controller-revision-hash": "644fc947f8",
+                    "k8s-app": "cilium",
+                    "pod-template-generation": "5"
+                },
+                "name": "cilium-bbm6t",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "DaemonSet",
+                        "name": "cilium",
+                        "uid": "6a7d5dc2-66ea-433d-a3c7-324dc0b55c87"
+                    }
+                ],
+                "resourceVersion": "2577",
+                "uid": "4e295c12-a6d8-4d9c-a564-209e8f990d71"
+            },
+            "spec": {
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchFields": [
+                                        {
+                                            "key": "metadata.name",
+                                            "operator": "In",
+                                            "values": [
+                                                "juju-98a2d4-7"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "podAntiAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "k8s-app": "cilium"
+                                    }
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": true,
+                "containers": [
+                    {
+                        "args": [
+                            "--config-dir=/tmp/cilium/config-map"
+                        ],
+                        "command": [
+                            "cilium-agent"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_CLUSTERMESH_CONFIG",
+                                "value": "/var/lib/cilium/clustermesh/"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "lifecycle": {
+                            "postStart": {
+                                "exec": {
+                                    "command": [
+                                        "bash",
+                                        "-c",
+                                        "set -o errexit\nset -o pipefail\nset -o nounset\n\n# When running in AWS ENI mode, it's likely that 'aws-node' has\n# had a chance to install SNAT iptables rules. These can result\n# in dropped traffic, so we should attempt to remove them.\n# We do it using a 'postStart' hook since this may need to run\n# for nodes which might have already been init'ed but may still\n# have dangling rules. This is safe because there are no\n# dependencies on anything that is part of the startup script\n# itself, and can be safely run multiple times per node (e.g. in\n# case of a restart).\nif [[ \"$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')\" != \"0\" ]];\nthen\n    echo 'Deleting iptables rules created by the AWS CNI VPC plugin'\n    iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore\nfi\necho 'Done!'\n"
+                                    ]
+                                }
+                            },
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "/cni-uninstall.sh"
+                                    ]
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "cilium-agent",
+                        "ports": [
+                            {
+                                "containerPort": 4244,
+                                "hostPort": 4244,
+                                "name": "peer-service",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9962,
+                                "hostPort": 9962,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9964,
+                                "hostPort": 9964,
+                                "name": "envoy-metrics",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9965,
+                                "hostPort": 9965,
+                                "name": "hubble-metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "startupProbe": {
+                            "failureThreshold": 105,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 2,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "mountPropagation": "Bidirectional",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "hostNetwork": true,
+                "initContainers": [
+                    {
+                        "command": [
+                            "cilium",
+                            "build-config"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "config",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-mount /hostbin/cilium-mount;\nnsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-mount\" $CGROUP_ROOT;\nrm /hostbin/cilium-mount\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "CGROUP_ROOT",
+                                "value": "/run/cilium/cgroupv2"
+                            },
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "mount-cgroup",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;\nnsenter --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-sysctlfix\";\nrm /hostbin/cilium-sysctlfix\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "apply-sysctl-overwrites",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/init-container.sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "CILIUM_ALL_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_BPF_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-bpf-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "clean-cilium-state",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "mountPropagation": "HostToContainer",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/install-plugin.sh"
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "install-cni-binaries",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "10Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "nodeName": "juju-98a2d4-7",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000001000,
+                "priorityClassName": "system-node-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "cilium",
+                "serviceAccountName": "cilium",
+                "terminationGracePeriodSeconds": 1,
+                "tolerations": [
+                    {
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/pid-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/unschedulable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/network-unavailable",
+                        "operator": "Exists"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "emptyDir": {},
+                        "name": "tmp"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/run/cilium",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-run"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/sys/fs/bpf",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "bpf-maps"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/proc",
+                            "type": "Directory"
+                        },
+                        "name": "hostproc"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/cilium/cgroupv2",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-cgroup"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/opt/cni/bin",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cni-path"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/etc/cni/net.d",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "etc-cni-netd"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/lib/modules",
+                            "type": ""
+                        },
+                        "name": "lib-modules"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/xtables.lock",
+                            "type": "FileOrCreate"
+                        },
+                        "name": "xtables-lock"
+                    },
+                    {
+                        "name": "clustermesh-secrets",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "name": "cilium-clustermesh",
+                                        "optional": true
+                                    }
+                                },
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.key",
+                                                "path": "common-etcd-client.key"
+                                            },
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "common-etcd-client.crt"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "common-etcd-client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "clustermesh-apiserver-remote-cert",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "hubble-tls",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "server.crt"
+                                            },
+                                            {
+                                                "key": "tls.key",
+                                                "path": "server.key"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "hubble-server-certs",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "kube-api-access-ds6zd",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:53Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:57Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:45Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:45Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:52Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://51d25b4cf46e4017df8b22acbabd4a40e2b7d9639e7ba856e968d91e3e666b00",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "cilium-agent",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T17:41:57Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.98",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.98"
+                    }
+                ],
+                "initContainerStatuses": [
+                    {
+                        "containerID": "containerd://94436bac5c833571c83ce3885d84caa9dbe4b76925b4a8846026b685dfffa3fd",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "config",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://94436bac5c833571c83ce3885d84caa9dbe4b76925b4a8846026b685dfffa3fd",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:41:52Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:41:52Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://7b2fe7d17553c1efbbbc3ef434d2f637a6f864637b84c2081c42fd72fd96e4a8",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "mount-cgroup",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://7b2fe7d17553c1efbbbc3ef434d2f637a6f864637b84c2081c42fd72fd96e4a8",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:41:53Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:41:53Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://2f7a90b0e6403fc1924834875ea9d1ded2b743dff27e169ac4452adb6a419721",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "apply-sysctl-overwrites",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://2f7a90b0e6403fc1924834875ea9d1ded2b743dff27e169ac4452adb6a419721",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:41:54Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:41:54Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://76abd21288e5239d69b3aa1b69f27cca0ee8b6bc805e52801ec146f07b79ff11",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "clean-cilium-state",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://76abd21288e5239d69b3aa1b69f27cca0ee8b6bc805e52801ec146f07b79ff11",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:41:55Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:41:55Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://774df922d5f3453db42ea0d782a7853797c87c4c910d0b3ba75330519ae566e5",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "install-cni-binaries",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://774df922d5f3453db42ea0d782a7853797c87c4c910d0b3ba75330519ae566e5",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:41:56Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:41:56Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-ds6zd",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "phase": "Pending",
+                "podIP": "10.246.154.98",
+                "podIPs": [
+                    {
+                        "ip": "10.246.154.98"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2024-08-26T17:41:52Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "juju.is/manifest-hash": "c66a480b7e55014bf9672cf16d291e26abd9d48f9a480dc66f6d2d9a3c5d9dcd"
+                },
+                "creationTimestamp": "2024-08-26T17:41:23Z",
+                "generateName": "cilium-",
+                "labels": {
+                    "app.kubernetes.io/name": "cilium-agent",
+                    "app.kubernetes.io/part-of": "cilium",
+                    "controller-revision-hash": "644fc947f8",
+                    "k8s-app": "cilium",
+                    "pod-template-generation": "5"
+                },
+                "name": "cilium-khfzq",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "DaemonSet",
+                        "name": "cilium",
+                        "uid": "6a7d5dc2-66ea-433d-a3c7-324dc0b55c87"
+                    }
+                ],
+                "resourceVersion": "2654",
+                "uid": "b0d05eb0-6451-4d4e-aaa1-8fb7e466081a"
+            },
+            "spec": {
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchFields": [
+                                        {
+                                            "key": "metadata.name",
+                                            "operator": "In",
+                                            "values": [
+                                                "juju-98a2d4-8"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "podAntiAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "k8s-app": "cilium"
+                                    }
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": true,
+                "containers": [
+                    {
+                        "args": [
+                            "--config-dir=/tmp/cilium/config-map"
+                        ],
+                        "command": [
+                            "cilium-agent"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_CLUSTERMESH_CONFIG",
+                                "value": "/var/lib/cilium/clustermesh/"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "lifecycle": {
+                            "postStart": {
+                                "exec": {
+                                    "command": [
+                                        "bash",
+                                        "-c",
+                                        "set -o errexit\nset -o pipefail\nset -o nounset\n\n# When running in AWS ENI mode, it's likely that 'aws-node' has\n# had a chance to install SNAT iptables rules. These can result\n# in dropped traffic, so we should attempt to remove them.\n# We do it using a 'postStart' hook since this may need to run\n# for nodes which might have already been init'ed but may still\n# have dangling rules. This is safe because there are no\n# dependencies on anything that is part of the startup script\n# itself, and can be safely run multiple times per node (e.g. in\n# case of a restart).\nif [[ \"$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')\" != \"0\" ]];\nthen\n    echo 'Deleting iptables rules created by the AWS CNI VPC plugin'\n    iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore\nfi\necho 'Done!'\n"
+                                    ]
+                                }
+                            },
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "/cni-uninstall.sh"
+                                    ]
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "cilium-agent",
+                        "ports": [
+                            {
+                                "containerPort": 4244,
+                                "hostPort": 4244,
+                                "name": "peer-service",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9962,
+                                "hostPort": 9962,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9964,
+                                "hostPort": 9964,
+                                "name": "envoy-metrics",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9965,
+                                "hostPort": 9965,
+                                "name": "hubble-metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "startupProbe": {
+                            "failureThreshold": 105,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 2,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "mountPropagation": "Bidirectional",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "hostNetwork": true,
+                "initContainers": [
+                    {
+                        "command": [
+                            "cilium",
+                            "build-config"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "config",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-mount /hostbin/cilium-mount;\nnsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-mount\" $CGROUP_ROOT;\nrm /hostbin/cilium-mount\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "CGROUP_ROOT",
+                                "value": "/run/cilium/cgroupv2"
+                            },
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "mount-cgroup",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;\nnsenter --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-sysctlfix\";\nrm /hostbin/cilium-sysctlfix\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "apply-sysctl-overwrites",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/init-container.sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "CILIUM_ALL_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_BPF_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-bpf-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "clean-cilium-state",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "mountPropagation": "HostToContainer",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/install-plugin.sh"
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "install-cni-binaries",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "10Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "nodeName": "juju-98a2d4-8",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000001000,
+                "priorityClassName": "system-node-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "cilium",
+                "serviceAccountName": "cilium",
+                "terminationGracePeriodSeconds": 1,
+                "tolerations": [
+                    {
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/pid-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/unschedulable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/network-unavailable",
+                        "operator": "Exists"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "emptyDir": {},
+                        "name": "tmp"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/run/cilium",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-run"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/sys/fs/bpf",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "bpf-maps"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/proc",
+                            "type": "Directory"
+                        },
+                        "name": "hostproc"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/cilium/cgroupv2",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-cgroup"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/opt/cni/bin",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cni-path"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/etc/cni/net.d",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "etc-cni-netd"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/lib/modules",
+                            "type": ""
+                        },
+                        "name": "lib-modules"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/xtables.lock",
+                            "type": "FileOrCreate"
+                        },
+                        "name": "xtables-lock"
+                    },
+                    {
+                        "name": "clustermesh-secrets",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "name": "cilium-clustermesh",
+                                        "optional": true
+                                    }
+                                },
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.key",
+                                                "path": "common-etcd-client.key"
+                                            },
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "common-etcd-client.crt"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "common-etcd-client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "clustermesh-apiserver-remote-cert",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "hubble-tls",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "server.crt"
+                                            },
+                                            {
+                                                "key": "tls.key",
+                                                "path": "server.key"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "hubble-server-certs",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "kube-api-access-7gbpn",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:26Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:32Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:43:01Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:43:01Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:09Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://a9b40a5dd689f08224f8e5a88e41eaa1b32a028030cbdf90c52f88bd406b6fbc",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "cilium-agent",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T17:42:33Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.236",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.236"
+                    }
+                ],
+                "initContainerStatuses": [
+                    {
+                        "containerID": "containerd://a49859c57504a544169da2da86911207bdab8eeccbe67bbdaaf1449274187d07",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "config",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://a49859c57504a544169da2da86911207bdab8eeccbe67bbdaaf1449274187d07",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:26Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:26Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://154d0ee4a1541d95c88e9f44a18f40d9a64dcd22ead56fabe06ec9527d102aeb",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "mount-cgroup",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://154d0ee4a1541d95c88e9f44a18f40d9a64dcd22ead56fabe06ec9527d102aeb",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:29Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:29Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://5df5680509a2aff2fe5590f645400a087cb9aa92e0951080de692342ee13f382",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "apply-sysctl-overwrites",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://5df5680509a2aff2fe5590f645400a087cb9aa92e0951080de692342ee13f382",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:30Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:30Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://d827ad8278da5112f7e4406cee968d904e6eaaaeb072cccc320370877bbdaa4f",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "clean-cilium-state",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://d827ad8278da5112f7e4406cee968d904e6eaaaeb072cccc320370877bbdaa4f",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:31Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:31Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://0ce7169a44f15db02c53b8fe87fb0629cc3d87034dbd47f806e0462948067819",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "install-cni-binaries",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://0ce7169a44f15db02c53b8fe87fb0629cc3d87034dbd47f806e0462948067819",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:32Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:32Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-7gbpn",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.246.154.236",
+                "podIPs": [
+                    {
+                        "ip": "10.246.154.236"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2024-08-26T17:42:09Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "juju.is/manifest-hash": "c66a480b7e55014bf9672cf16d291e26abd9d48f9a480dc66f6d2d9a3c5d9dcd"
+                },
+                "creationTimestamp": "2024-08-26T17:42:14Z",
+                "generateName": "cilium-",
+                "labels": {
+                    "app.kubernetes.io/name": "cilium-agent",
+                    "app.kubernetes.io/part-of": "cilium",
+                    "controller-revision-hash": "644fc947f8",
+                    "k8s-app": "cilium",
+                    "pod-template-generation": "5"
+                },
+                "name": "cilium-nt9nc",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "DaemonSet",
+                        "name": "cilium",
+                        "uid": "6a7d5dc2-66ea-433d-a3c7-324dc0b55c87"
+                    }
+                ],
+                "resourceVersion": "2380",
+                "uid": "577c8736-11c7-4f1d-a28a-1429d68ab5bf"
+            },
+            "spec": {
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchFields": [
+                                        {
+                                            "key": "metadata.name",
+                                            "operator": "In",
+                                            "values": [
+                                                "juju-98a2d4-5"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "podAntiAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "k8s-app": "cilium"
+                                    }
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": true,
+                "containers": [
+                    {
+                        "args": [
+                            "--config-dir=/tmp/cilium/config-map"
+                        ],
+                        "command": [
+                            "cilium-agent"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_CLUSTERMESH_CONFIG",
+                                "value": "/var/lib/cilium/clustermesh/"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "lifecycle": {
+                            "postStart": {
+                                "exec": {
+                                    "command": [
+                                        "bash",
+                                        "-c",
+                                        "set -o errexit\nset -o pipefail\nset -o nounset\n\n# When running in AWS ENI mode, it's likely that 'aws-node' has\n# had a chance to install SNAT iptables rules. These can result\n# in dropped traffic, so we should attempt to remove them.\n# We do it using a 'postStart' hook since this may need to run\n# for nodes which might have already been init'ed but may still\n# have dangling rules. This is safe because there are no\n# dependencies on anything that is part of the startup script\n# itself, and can be safely run multiple times per node (e.g. in\n# case of a restart).\nif [[ \"$(iptables-save | grep -E -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')\" != \"0\" ]];\nthen\n    echo 'Deleting iptables rules created by the AWS CNI VPC plugin'\n    iptables-save | grep -E -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore\nfi\necho 'Done!'\n"
+                                    ]
+                                }
+                            },
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "/cni-uninstall.sh"
+                                    ]
+                                }
+                            }
+                        },
+                        "livenessProbe": {
+                            "failureThreshold": 10,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "cilium-agent",
+                        "ports": [
+                            {
+                                "containerPort": 4244,
+                                "hostPort": 4244,
+                                "name": "peer-service",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9962,
+                                "hostPort": 9962,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9964,
+                                "hostPort": 9964,
+                                "name": "envoy-metrics",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9965,
+                                "hostPort": 9965,
+                                "name": "hubble-metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "startupProbe": {
+                            "failureThreshold": 105,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "httpHeaders": [
+                                    {
+                                        "name": "brief",
+                                        "value": "true"
+                                    }
+                                ],
+                                "path": "/healthz",
+                                "port": 9879,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 2,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "mountPropagation": "Bidirectional",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "hostNetwork": true,
+                "initContainers": [
+                    {
+                        "command": [
+                            "cilium",
+                            "build-config"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "config",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-mount /hostbin/cilium-mount;\nnsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-mount\" $CGROUP_ROOT;\nrm /hostbin/cilium-mount\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "CGROUP_ROOT",
+                                "value": "/run/cilium/cgroupv2"
+                            },
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "mount-cgroup",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "sh",
+                            "-ec",
+                            "cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;\nnsenter --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-sysctlfix\";\nrm /hostbin/cilium-sysctlfix\n"
+                        ],
+                        "env": [
+                            {
+                                "name": "BIN_PATH",
+                                "value": "/opt/cni/bin"
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "apply-sysctl-overwrites",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/init-container.sh"
+                        ],
+                        "env": [
+                            {
+                                "name": "CILIUM_ALL_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_BPF_STATE",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "clean-cilium-bpf-state",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "clean-cilium-state",
+                        "resources": {},
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "mountPropagation": "HostToContainer",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/install-plugin.sh"
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/cilium:v1.14.11@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "install-cni-binaries",
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "10Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "privileged": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "nodeName": "juju-98a2d4-5",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000001000,
+                "priorityClassName": "system-node-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "cilium",
+                "serviceAccountName": "cilium",
+                "terminationGracePeriodSeconds": 1,
+                "tolerations": [
+                    {
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/disk-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/memory-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/pid-pressure",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/unschedulable",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node.kubernetes.io/network-unavailable",
+                        "operator": "Exists"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "emptyDir": {},
+                        "name": "tmp"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/var/run/cilium",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-run"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/sys/fs/bpf",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "bpf-maps"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/proc",
+                            "type": "Directory"
+                        },
+                        "name": "hostproc"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/cilium/cgroupv2",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cilium-cgroup"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/opt/cni/bin",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "cni-path"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/etc/cni/net.d",
+                            "type": "DirectoryOrCreate"
+                        },
+                        "name": "etc-cni-netd"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/lib/modules",
+                            "type": ""
+                        },
+                        "name": "lib-modules"
+                    },
+                    {
+                        "hostPath": {
+                            "path": "/run/xtables.lock",
+                            "type": "FileOrCreate"
+                        },
+                        "name": "xtables-lock"
+                    },
+                    {
+                        "name": "clustermesh-secrets",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "name": "cilium-clustermesh",
+                                        "optional": true
+                                    }
+                                },
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.key",
+                                                "path": "common-etcd-client.key"
+                                            },
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "common-etcd-client.crt"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "common-etcd-client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "clustermesh-apiserver-remote-cert",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "hubble-tls",
+                        "projected": {
+                            "defaultMode": 256,
+                            "sources": [
+                                {
+                                    "secret": {
+                                        "items": [
+                                            {
+                                                "key": "tls.crt",
+                                                "path": "server.crt"
+                                            },
+                                            {
+                                                "key": "tls.key",
+                                                "path": "server.key"
+                                            },
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "client-ca.crt"
+                                            }
+                                        ],
+                                        "name": "hubble-server-certs",
+                                        "optional": true
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "name": "kube-api-access-b79gh",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:15Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:19Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:26Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:26Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:14Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://cfb574aa08e161f3b37d8548907e5bee478e0a5b11d85d5dad221b766c09d9ad",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "cilium-agent",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T17:42:19Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/host/etc/cni/net.d",
+                                "name": "etc-cni-netd"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/clustermesh",
+                                "name": "clustermesh-secrets",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/lib/modules",
+                                "name": "lib-modules",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/run/xtables.lock",
+                                "name": "xtables-lock"
+                            },
+                            {
+                                "mountPath": "/var/lib/cilium/tls/hubble",
+                                "name": "hubble-tls",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.61",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.61"
+                    }
+                ],
+                "initContainerStatuses": [
+                    {
+                        "containerID": "containerd://b55b50025fcd802b39a65eeca1d8e4d24baba2f554089be82779ddd99dda8e6c",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "config",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://b55b50025fcd802b39a65eeca1d8e4d24baba2f554089be82779ddd99dda8e6c",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:15Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:14Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://3707a8d92714d1cba52e0bde2abc8de2816430589c35e3bb3167a4703447b4dd",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "mount-cgroup",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://3707a8d92714d1cba52e0bde2abc8de2816430589c35e3bb3167a4703447b4dd",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:15Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:15Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://2c27c5a47f1013dd34b4491c4c12a01899fe434d932dd5c0c3dae657ca8466ed",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "apply-sysctl-overwrites",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://2c27c5a47f1013dd34b4491c4c12a01899fe434d932dd5c0c3dae657ca8466ed",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:16Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:16Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/hostproc",
+                                "name": "hostproc"
+                            },
+                            {
+                                "mountPath": "/hostbin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://719707b570fe1a0af97cbddf67b4e9e9ca85b7743ca1ebb0b7ffc7b010fdb59f",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "clean-cilium-state",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://719707b570fe1a0af97cbddf67b4e9e9ca85b7743ca1ebb0b7ffc7b010fdb59f",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:17Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:17Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/sys/fs/bpf",
+                                "name": "bpf-maps"
+                            },
+                            {
+                                "mountPath": "/run/cilium/cgroupv2",
+                                "name": "cilium-cgroup"
+                            },
+                            {
+                                "mountPath": "/var/run/cilium",
+                                "name": "cilium-run"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://94c7476e6c22a40a15d396a380cec05413f38d7f6c80a126681faaac98b733f1",
+                        "image": "sha256:28f2114f67d9fe4c6b422678cfe9981a7cba4f7b657ad87a0fae124e9c6b4d74",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/cilium@sha256:2b2118042dc6efe88dbc40c78909b6afd72b369896782ce38d132435724ee269",
+                        "lastState": {},
+                        "name": "install-cni-binaries",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": false,
+                        "state": {
+                            "terminated": {
+                                "containerID": "containerd://94c7476e6c22a40a15d396a380cec05413f38d7f6c80a126681faaac98b733f1",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T17:42:18Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T17:42:18Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/host/opt/cni/bin",
+                                "name": "cni-path"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-b79gh",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.246.154.61",
+                "podIPs": [
+                    {
+                        "ip": "10.246.154.61"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2024-08-26T17:42:14Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "juju.is/manifest-hash": "c66a480b7e55014bf9672cf16d291e26abd9d48f9a480dc66f6d2d9a3c5d9dcd"
+                },
+                "creationTimestamp": "2024-08-26T17:41:23Z",
+                "generateName": "cilium-operator-69d85d477f-",
+                "labels": {
+                    "app.kubernetes.io/name": "cilium-operator",
+                    "app.kubernetes.io/part-of": "cilium",
+                    "io.cilium/app": "operator",
+                    "name": "cilium-operator",
+                    "pod-template-hash": "69d85d477f"
+                },
+                "name": "cilium-operator-69d85d477f-42dm8",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "cilium-operator-69d85d477f",
+                        "uid": "366b014c-e4a6-44ce-bde7-a1a804583f53"
+                    }
+                ],
+                "resourceVersion": "2061",
+                "uid": "7b125181-4a9a-4c77-8996-595e49b83157"
+            },
+            "spec": {
+                "affinity": {
+                    "podAntiAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "io.cilium/app": "operator"
+                                    }
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": true,
+                "containers": [
+                    {
+                        "args": [
+                            "--config-dir=/tmp/cilium/config-map",
+                            "--debug=$(CILIUM_DEBUG)"
+                        ],
+                        "command": [
+                            "cilium-operator-generic"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_DEBUG",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "debug",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/operator-generic:v1.14.11@sha256:df76f71a06f1c681848bfa86fdd99243af593d33034c9e2057c6af969bc25109",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "path": "/healthz",
+                                "port": 9234,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 3
+                        },
+                        "name": "cilium-operator",
+                        "ports": [
+                            {
+                                "containerPort": 9963,
+                                "hostPort": 9963,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 5,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "path": "/healthz",
+                                "port": 9234,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 3
+                        },
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp/cilium/config-map",
+                                "name": "cilium-config-path",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-x5lsx",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "hostNetwork": true,
+                "nodeName": "juju-98a2d4-5",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000000000,
+                "priorityClassName": "system-cluster-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "cilium-operator",
+                "serviceAccountName": "cilium-operator",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "operator": "Exists"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "name": "cilium-config"
+                        },
+                        "name": "cilium-config-path"
+                    },
+                    {
+                        "name": "kube-api-access-x5lsx",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:51Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:50Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:51Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:51Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:50Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://4c628568604ad1f0f04fea2dccb57e9215a3ead299e7e0fdd5fb8335aafbf1dd",
+                        "image": "sha256:5b03903fffc9b23a972764d9739b2159ae71b4a76bf4f37a07007e6004427613",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/operator-generic@sha256:df76f71a06f1c681848bfa86fdd99243af593d33034c9e2057c6af969bc25109",
+                        "lastState": {},
+                        "name": "cilium-operator",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T17:41:51Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp/cilium/config-map",
+                                "name": "cilium-config-path",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-x5lsx",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.61",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.61"
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.246.154.61",
+                "podIPs": [
+                    {
+                        "ip": "10.246.154.61"
+                    }
+                ],
+                "qosClass": "BestEffort",
+                "startTime": "2024-08-26T17:41:50Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "juju.is/manifest-hash": "c66a480b7e55014bf9672cf16d291e26abd9d48f9a480dc66f6d2d9a3c5d9dcd"
+                },
+                "creationTimestamp": "2024-08-26T17:41:23Z",
+                "generateName": "cilium-operator-69d85d477f-",
+                "labels": {
+                    "app.kubernetes.io/name": "cilium-operator",
+                    "app.kubernetes.io/part-of": "cilium",
+                    "io.cilium/app": "operator",
+                    "name": "cilium-operator",
+                    "pod-template-hash": "69d85d477f"
+                },
+                "name": "cilium-operator-69d85d477f-f97fv",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "cilium-operator-69d85d477f",
+                        "uid": "366b014c-e4a6-44ce-bde7-a1a804583f53"
+                    }
+                ],
+                "resourceVersion": "2533",
+                "uid": "7c3c3f6c-a4ae-4971-b472-6874b399408e"
+            },
+            "spec": {
+                "affinity": {
+                    "podAntiAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "io.cilium/app": "operator"
+                                    }
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "automountServiceAccountToken": true,
+                "containers": [
+                    {
+                        "args": [
+                            "--config-dir=/tmp/cilium/config-map",
+                            "--debug=$(CILIUM_DEBUG)"
+                        ],
+                        "command": [
+                            "cilium-operator-generic"
+                        ],
+                        "env": [
+                            {
+                                "name": "K8S_NODE_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "spec.nodeName"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_K8S_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "CILIUM_DEBUG",
+                                "valueFrom": {
+                                    "configMapKeyRef": {
+                                        "key": "debug",
+                                        "name": "cilium-config",
+                                        "optional": true
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/cilium/operator-generic:v1.14.11@sha256:df76f71a06f1c681848bfa86fdd99243af593d33034c9e2057c6af969bc25109",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "path": "/healthz",
+                                "port": 9234,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 3
+                        },
+                        "name": "cilium-operator",
+                        "ports": [
+                            {
+                                "containerPort": 9963,
+                                "hostPort": 9963,
+                                "name": "prometheus",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 5,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "path": "/healthz",
+                                "port": 9234,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 3
+                        },
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp/cilium/config-map",
+                                "name": "cilium-config-path",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-tlkst",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "hostNetwork": true,
+                "nodeName": "juju-98a2d4-7",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000000000,
+                "priorityClassName": "system-cluster-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "cilium-operator",
+                "serviceAccountName": "cilium-operator",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "operator": "Exists"
+                    }
+                ],
+                "volumes": [
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "name": "cilium-config"
+                        },
+                        "name": "cilium-config-path"
+                    },
+                    {
+                        "name": "kube-api-access-tlkst",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:52Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:50Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:38Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:38Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:41:50Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://62185c6e85c7825802f0d45f7f07dc4547d2bc9dc9a2315b1e86d4e65ba940c2",
+                        "image": "sha256:5b03903fffc9b23a972764d9739b2159ae71b4a76bf4f37a07007e6004427613",
+                        "imageID": "rocks.canonical.com:443/cdk/cilium/operator-generic@sha256:df76f71a06f1c681848bfa86fdd99243af593d33034c9e2057c6af969bc25109",
+                        "lastState": {},
+                        "name": "cilium-operator",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T17:41:51Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp/cilium/config-map",
+                                "name": "cilium-config-path",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-tlkst",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.98",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.98"
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.246.154.98",
+                "podIPs": [
+                    {
+                        "ip": "10.246.154.98"
+                    }
+                ],
+                "qosClass": "BestEffort",
+                "startTime": "2024-08-26T17:41:50Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "creationTimestamp": "2024-08-26T17:37:25Z",
+                "generateName": "coredns-5b4857d7c8-",
+                "labels": {
+                    "app.kubernetes.io/name": "coredns",
+                    "k8s-app": "kube-dns",
+                    "pod-template-hash": "5b4857d7c8"
+                },
+                "name": "coredns-5b4857d7c8-ckc9v",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "coredns-5b4857d7c8",
+                        "uid": "3f9efaf7-bf82-4717-8893-f4dfddcc407a"
+                    }
+                ],
+                "resourceVersion": "8798",
+                "uid": "20075c8f-7ea3-41a5-a5bf-d7ca755f835a"
+            },
+            "spec": {
+                "affinity": {
+                    "podAntiAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "labelSelector": {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "k8s-app",
+                                            "operator": "In",
+                                            "values": [
+                                                "kube-dns"
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "topologyKey": "kubernetes.io/hostname"
+                            }
+                        ]
+                    }
+                },
+                "containers": [
+                    {
+                        "args": [
+                            "-conf",
+                            "/etc/coredns/Corefile"
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/coredns/coredns:1.9.4",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 5,
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "coredns",
+                        "ports": [
+                            {
+                                "containerPort": 53,
+                                "name": "dns",
+                                "protocol": "UDP"
+                            },
+                            {
+                                "containerPort": 53,
+                                "name": "dns-tcp",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9153,
+                                "name": "metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/ready",
+                                "port": 8181,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "memory": "170Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "70Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "add": [
+                                    "NET_BIND_SERVICE"
+                                ],
+                                "drop": [
+                                    "all"
+                                ]
+                            },
+                            "readOnlyRootFilesystem": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/coredns",
+                                "name": "config-volume",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-bk67v",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "Default",
+                "enableServiceLinks": true,
+                "nodeName": "juju-98a2d4-7",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000000000,
+                "priorityClassName": "system-cluster-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "coredns",
+                "serviceAccountName": "coredns",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "items": [
+                                {
+                                    "key": "Corefile",
+                                    "path": "Corefile"
+                                }
+                            ],
+                            "name": "coredns"
+                        },
+                        "name": "config-volume"
+                    },
+                    {
+                        "name": "kube-api-access-bk67v",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:49Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:32Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:45Z",
+                        "message": "containers with unready status: [coredns]",
+                        "reason": "ContainersNotReady",
+                        "status": "False",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:45Z",
+                        "message": "containers with unready status: [coredns]",
+                        "reason": "ContainersNotReady",
+                        "status": "False",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:32Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://1bb941676b1d81c1bb4eaf0d5e04e7333b4e04c0aef48f7c97a29bbfb7f674e4",
+                        "image": "rocks.canonical.com:443/cdk/coredns/coredns:1.9.4",
+                        "imageID": "rocks.canonical.com:443/cdk/coredns/coredns@sha256:b82e294de6be763f73ae71266c8f5466e7e03c69f3a1de96efd570284d35bb18",
+                        "lastState": {
+                            "terminated": {
+                                "containerID": "containerd://190e1cf746202c762661116a57321c3c4856649ad3c59f65797d132cc0173f2c",
+                                "exitCode": 0,
+                                "finishedAt": "2024-08-26T18:22:25Z",
+                                "reason": "Completed",
+                                "startedAt": "2024-08-26T18:20:26Z"
+                            }
+                        },
+                        "name": "coredns",
+                        "ready": false,
+                        "restartCount": 13,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T18:22:25Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/coredns",
+                                "name": "config-volume",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-bk67v",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.98",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.98"
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.0.1.223",
+                "podIPs": [
+                    {
+                        "ip": "10.0.1.223"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2024-08-26T17:39:32Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "creationTimestamp": "2024-08-26T17:37:25Z",
+                "generateName": "kube-state-metrics-5d7bdccd49-",
+                "labels": {
+                    "app.kubernetes.io/component": "exporter",
+                    "app.kubernetes.io/name": "kube-state-metrics",
+                    "app.kubernetes.io/version": "2.10.1",
+                    "pod-template-hash": "5d7bdccd49"
+                },
+                "name": "kube-state-metrics-5d7bdccd49-h5gcl",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "kube-state-metrics-5d7bdccd49",
+                        "uid": "5b38e7d2-7661-4abc-a86c-2cc326e579e9"
+                    }
+                ],
+                "resourceVersion": "8357",
+                "uid": "461d99c1-a6ba-45ee-a41d-a03364cbc815"
+            },
+            "spec": {
+                "automountServiceAccountToken": true,
+                "containers": [
+                    {
+                        "image": "rocks.canonical.com:443/cdk/kube-state-metrics/kube-state-metrics:v2.10.1",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/healthz",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "kube-state-metrics",
+                        "ports": [
+                            {
+                                "containerPort": 8080,
+                                "name": "http-metrics",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 8081,
+                                "name": "telemetry",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 8081,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "resources": {},
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "readOnlyRootFilesystem": true,
+                            "runAsNonRoot": true,
+                            "runAsUser": 65534,
+                            "seccompProfile": {
+                                "type": "RuntimeDefault"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-bg68q",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "nodeName": "juju-98a2d4-7",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 0,
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "kube-state-metrics",
+                "serviceAccountName": "kube-state-metrics",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "kube-api-access-bg68q",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:52Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:33Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:39Z",
+                        "message": "containers with unready status: [kube-state-metrics]",
+                        "reason": "ContainersNotReady",
+                        "status": "False",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:42:39Z",
+                        "message": "containers with unready status: [kube-state-metrics]",
+                        "reason": "ContainersNotReady",
+                        "status": "False",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:32Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://f323c556258b76d2573940bc17bca0a688be61e956f773b4b9db04a0a3c63651",
+                        "image": "rocks.canonical.com:443/cdk/kube-state-metrics/kube-state-metrics:v2.10.1",
+                        "imageID": "rocks.canonical.com:443/cdk/kube-state-metrics/kube-state-metrics@sha256:af8220f534938de121a694cb7314313a6195c9d494fc30bfa6885b08a276bb82",
+                        "lastState": {
+                            "terminated": {
+                                "containerID": "containerd://f323c556258b76d2573940bc17bca0a688be61e956f773b4b9db04a0a3c63651",
+                                "exitCode": 1,
+                                "finishedAt": "2024-08-26T18:19:24Z",
+                                "reason": "Error",
+                                "startedAt": "2024-08-26T18:18:54Z"
+                            }
+                        },
+                        "name": "kube-state-metrics",
+                        "ready": false,
+                        "restartCount": 18,
+                        "started": false,
+                        "state": {
+                            "waiting": {
+                                "message": "back-off 5m0s restarting failed container=kube-state-metrics pod=kube-state-metrics-5d7bdccd49-h5gcl_kube-system(461d99c1-a6ba-45ee-a41d-a03364cbc815)",
+                                "reason": "CrashLoopBackOff"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-bg68q",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.98",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.98"
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.0.1.208",
+                "podIPs": [
+                    {
+                        "ip": "10.0.1.208"
+                    }
+                ],
+                "qosClass": "BestEffort",
+                "startTime": "2024-08-26T17:39:33Z"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "creationTimestamp": "2024-08-26T17:37:25Z",
+                "generateName": "metrics-server-v0.7.1-6c77d69467-",
+                "labels": {
+                    "k8s-app": "metrics-server",
+                    "pod-template-hash": "6c77d69467",
+                    "version": "v0.7.1"
+                },
+                "name": "metrics-server-v0.7.1-6c77d69467-24bh9",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "metrics-server-v0.7.1-6c77d69467",
+                        "uid": "54448b59-a39d-4659-be51-f6d074449f93"
+                    }
+                ],
+                "resourceVersion": "8535",
+                "uid": "76467b60-4b6e-4cba-9bed-352b160a436a"
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "command": [
+                            "/metrics-server",
+                            "--metric-resolution=15s",
+                            "--kubelet-use-node-status-port",
+                            "--kubelet-insecure-tls",
+                            "--kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP",
+                            "--cert-dir=/tmp",
+                            "--secure-port=10250"
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/metrics-server/metrics-server:v0.7.1",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/livez",
+                                "port": "https",
+                                "scheme": "HTTPS"
+                            },
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "name": "metrics-server",
+                        "ports": [
+                            {
+                                "containerPort": 10250,
+                                "name": "https",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/readyz",
+                                "port": "https",
+                                "scheme": "HTTPS"
+                            },
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp-dir"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wdzhd",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "command": [
+                            "/pod_nanny",
+                            "--config-dir=/etc/config",
+                            "--cpu=40m",
+                            "--extra-cpu=0.5m",
+                            "--memory=40Mi",
+                            "--extra-memory=4Mi",
+                            "--threshold=5",
+                            "--deployment=metrics-server-v0.7.1",
+                            "--container=metrics-server",
+                            "--poll-period=30000",
+                            "--estimator=exponential",
+                            "--minClusterSize=16",
+                            "--use-metrics=true"
+                        ],
+                        "env": [
+                            {
+                                "name": "MY_POD_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.name"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "MY_POD_NAMESPACE",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.namespace"
+                                    }
+                                }
+                            }
+                        ],
+                        "image": "rocks.canonical.com:443/cdk/addon-resizer-amd64:1.8.9",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "metrics-server-nanny",
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "300Mi"
+                            },
+                            "requests": {
+                                "cpu": "5m",
+                                "memory": "50Mi"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/config",
+                                "name": "metrics-server-config-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wdzhd",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "enableServiceLinks": true,
+                "nodeName": "juju-98a2d4-7",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000000000,
+                "priorityClassName": "system-cluster-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {
+                    "seccompProfile": {
+                        "type": "RuntimeDefault"
+                    }
+                },
+                "serviceAccount": "metrics-server",
+                "serviceAccountName": "metrics-server",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "name": "metrics-server-config"
+                        },
+                        "name": "metrics-server-config-volume"
+                    },
+                    {
+                        "emptyDir": {},
+                        "name": "tmp-dir"
+                    },
+                    {
+                        "name": "kube-api-access-wdzhd",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:57Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:33Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:33Z",
+                        "message": "containers with unready status: [metrics-server]",
+                        "reason": "ContainersNotReady",
+                        "status": "False",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:33Z",
+                        "message": "containers with unready status: [metrics-server]",
+                        "reason": "ContainersNotReady",
+                        "status": "False",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2024-08-26T17:39:32Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://0a6bd0be52a309cc49971c81a883087c49febdc341092d33c29d054ef5f4e6be",
+                        "image": "rocks.canonical.com:443/cdk/metrics-server/metrics-server:v0.7.1",
+                        "imageID": "rocks.canonical.com:443/cdk/metrics-server/metrics-server@sha256:db3800085a0957083930c3932b17580eec652cfb6156a05c0f79c7543e80d17a",
+                        "lastState": {
+                            "terminated": {
+                                "containerID": "containerd://0a6bd0be52a309cc49971c81a883087c49febdc341092d33c29d054ef5f4e6be",
+                                "exitCode": 2,
+                                "finishedAt": "2024-08-26T18:20:39Z",
+                                "reason": "Error",
+                                "startedAt": "2024-08-26T18:20:09Z"
+                            }
+                        },
+                        "name": "metrics-server",
+                        "ready": false,
+                        "restartCount": 18,
+                        "started": false,
+                        "state": {
+                            "waiting": {
+                                "message": "back-off 5m0s restarting failed container=metrics-server pod=metrics-server-v0.7.1-6c77d69467-24bh9_kube-system(76467b60-4b6e-4cba-9bed-352b160a436a)",
+                                "reason": "CrashLoopBackOff"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/tmp",
+                                "name": "tmp-dir"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wdzhd",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    },
+                    {
+                        "containerID": "containerd://fc4907bdeb39e095ed69ff2ce88ff2f6fd8e9547fb7760b4a17db4196807aa5f",
+                        "image": "rocks.canonical.com:443/cdk/addon-resizer-amd64:1.8.9",
+                        "imageID": "rocks.canonical.com:443/cdk/addon-resizer-amd64@sha256:b560b2131195cadd1b92b0b54d972e64932e8fe3d4881254732f582474b02eba",
+                        "lastState": {},
+                        "name": "metrics-server-nanny",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2024-08-26T17:40:14Z"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/config",
+                                "name": "metrics-server-config-volume"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-wdzhd",
+                                "readOnly": true,
+                                "recursiveReadOnly": "Disabled"
+                            }
+                        ]
+                    }
+                ],
+                "hostIP": "10.246.154.98",
+                "hostIPs": [
+                    {
+                        "ip": "10.246.154.98"
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.0.1.167",
+                "podIPs": [
+                    {
+                        "ip": "10.0.1.167"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2024-08-26T17:39:33Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}

--- a/tests/unit/test_kube_system.py
+++ b/tests/unit/test_kube_system.py
@@ -1,0 +1,27 @@
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+import yaml
+
+import k8s_kube_system
+
+
+@pytest.fixture
+def get_pods():
+    path = Path("tests/data/kube-system-pods.yaml")
+    with mock.patch("k8s_kube_system.get_pods") as get_pods:
+        get_pods.return_value = yaml.safe_load(path.open())
+        yield get_pods
+
+
+def test_get_kube_system_pods_not_running(get_pods):
+    # This test is incomplete. You need to complete it.
+    charm = mock.MagicMock()
+    charm.config = {"ignore-kube-system-pods": "kube-state-metrics"}
+    pods = k8s_kube_system.get_kube_system_pods_not_running(charm)
+    assert len(pods) == 3
+    get_pods.assert_called_once_with("kube-system")
+    pod_names = [pod["metadata"]["name"] for pod in pods]
+    assert pod_names[0] == "cilium-bbm6t"
+    assert pod_names[2] == "metrics-server-v0.7.1-6c77d69467-24bh9"


### PR DESCRIPTION
### Overview

Partially Addresses [LP#2032533](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2032533) by marking k-cp units in Waiting status when they have non-ready pods.  

### Details

* By checking the ready status of each of the containers in a pod, we can determine if the kube-system pods aren't ready and therefore mark the unit as "Waiting"
* This would have been helpful when spotting failing units caused by an incomplete cilium deployment
