### PR TITLE
[LP#2091126] Return the correct internal lb response

### DIFF
--- a/src/k8s_api_endpoints.py
+++ b/src/k8s_api_endpoints.py
@@ -38,8 +38,8 @@ class K8sApiEndpoints:
         return response.address
 
     def get_internal_api_endpoint(self) -> Optional[str]:
-        """Endpoint address from the loadbalancer-external relation."""
-        response = self.charm.lb_external.get_response("api-server-internal")
+        """Endpoint address from the loadbalancer-internal relation."""
+        response = self.charm.lb_internal.get_response("api-server-internal")
         if not response or response.error:
             return None
         return response.address


### PR DESCRIPTION
### Overview
* Addresses [LP#2091126](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2091126)
* Reverts copy-paste mistake from #327