### PR TITLE
Address failing grafana-agent relation at CK boot

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -39,13 +39,13 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp
       - name: Upload charmcraft logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charmcraft-logs
           path: "/home/ubuntu/.local/state/charmcraft/log/*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-inte
 ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops
 ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@main#subdirectory=ops
 aiohttp == 3.7.4
-cosl == 0.0.7
+cosl==0.0.47
 jinja2 == 3.1.3
 loadbalancer_interface == 1.2.0
 ops == 2.12.0

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -3,5 +3,11 @@ applications:
   kubernetes-control-plane:
     charm: {{charm}}
     channel: null
+    series: {{series}}
     resources:
       cni-plugins: {{resource_path}}/cni-plugins-{{arch}}.tar.gz
+  grafana-agent:
+    charm: grafana-agent
+    series: {{series}}
+relations:
+- [ kubernetes-control-plane:cos-agent, grafana-agent:cos-agent ]


### PR DESCRIPTION
Addresses [LP#2087936](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2087936)

### Overview

Because the COSAgentProvider reacts to all kinds of refresh_events, an event can call `get_scrape_jobs` before the charms have setup the cluster.   These changes protect against the call too early,

### Details
* protect get_scrape_jobs
* refresh when we configure observability during the reconcile loop
* Update cosl and cos_agent library