### PR TITLE
Pin config to 1.32/stable snaps and tests to 1.32/stable charms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -92,7 +92,7 @@ options:
       https://kubernetes.io/docs/reference/access-authn-authz/webhook/
   channel:
     type: string
-    default: "latest/edge"
+    default: "1.32/stable"
     description: |
       Snap channel to install Kubernetes control plane services from
   controller-manager-extra-args:

--- a/tests/integration/test_k8s_control_plane_charm.py
+++ b/tests/integration/test_k8s_control_plane_charm.py
@@ -33,7 +33,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     log.info("Building bundle")
     bundle, *overlays = await ops_test.async_render_bundles(
-        ops_test.Bundle("kubernetes-core", channel="edge", series=SERIES),
+        ops_test.Bundle("kubernetes-core", channel="1.32/stable", series=SERIES),
         Path("tests/data/charm.yaml"),
         arch="amd64",
         series=SERIES,

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -41,7 +41,7 @@ def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
     """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
 
     def mock_upgrade(channel, event, control_plane):
-        assert channel == "latest/edge"
+        assert channel == "1.32/stable"
         assert control_plane is True
         status.add(ops.BlockedStatus("snap-upgrade-failed"))
         event.fail("snap upgrade failed")


### PR DESCRIPTION
Per [release checklist](https://github.com/charmed-kubernetes/jenkins/blob/main/docs/releases/stable/index.md#pin-snap-channel-on-bundlescharms-in-the-release-branches)

Expect integration tests to fail because 1.32/stable charms don't yet exist