### PR TITLE
Update Prometheus rule for cpu usage to apply to all nodes

### DIFF
--- a/src/prometheus_alert_rules/kubernetesControlPlane-prometheusRule.yaml
+++ b/src/prometheus_alert_rules/kubernetesControlPlane-prometheusRule.yaml
@@ -1085,9 +1085,9 @@ groups:
 - name: k8s.rules
   rules:
   - expr: "sum by (cluster, namespace, pod, container) (\n  irate(container_cpu_usage_seconds_total{job=\"\
-      kubelet\", metrics_path=\"/metrics/cadvisor\", image!=\"\"}[5m])\n) * on (cluster,\
+      kubelet\", metrics_path=\"/metrics/cadvisor\", image!=\"\", juju_application=~\".+\"}[5m])\n) * on (cluster,\
       \ namespace, pod) group_left(node) topk by (cluster, namespace, pod) (\n  1,\
-      \ max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\"})\n)\n"
+      \ max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\", juju_application=~\".+\"})\n)\n"
     record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
   - expr: "container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"\
       , image!=\"\"}\n* on (cluster, namespace, pod) group_left(node) topk by(cluster,\


### PR DESCRIPTION
Add specific labels allowing all juju applications to prevent COS from adding a specific `juju_application`. As this rule is added from the control plane, COS would filter only for the `kubernetes-control-plane` application and so the rule would not apply for nodes running on worker nodes.
See canonical/prometheus-k8s-operator#667