### PR TITLE
Making sure groups variable is list

### DIFF
--- a/src/auth_webhook.py
+++ b/src/auth_webhook.py
@@ -130,6 +130,10 @@ def create_token(uid, username, groups=[]):
     # The authenticator expects tokens to be in the form user::token
     token = "{}::{}".format(uid, token_generator())
 
+    # make sure groups is list type. #2097158
+    if type(groups) != list:
+        groups = [groups]
+
     uid_b64 = b64encode(uid.encode("utf-8")).decode("utf-8")
     username_b64 = b64encode(username.encode("utf-8")).decode("utf-8")
     token_b64 = b64encode(token.encode("utf-8")).decode("utf-8")


### PR DESCRIPTION
When creating user, groups value are broken.

$ juju run kubernetes-control-plane/leader user-create name=trac groups=system:masters

$ kubectl get secrets -n kube-system $(kubectl get secrets -n kube-system | grep auth-trac | cut -d ' ' -f 1) -o json | jq -r '.data.groups' | base64 -d

s,y,s,t,e,m,:,m,a,s,t,e,r,s

https://github.com/charmed-kubernetes/charm-kubernetes-control-plane/blob/e0252948ab70479f241b666e01fd22f6b1a53b15/src/auth_webhook.py#L136

Credit:  Szilard Cserey

Fixes: LP#2097158
https://bugs.launchpad.net/charm-kubernetes-master/+bug/2097158