### PR TITLE
[LP#2097158] user create action ensures groups is a list of groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,11 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
-
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
 extend-exclude = ["__pycache__", "*.egg_info"]
+target-version = "py38"
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]

--- a/src/actions/users.py
+++ b/src/actions/users.py
@@ -35,7 +35,6 @@ def user_list(event: ops.ActionEvent):
 
 def user_create(charm, event: ops.ActionEvent):
     user = event.params["name"]
-    groups = event.params.get("groups") or ""
     if not protect_resources(user, event):
         return
 
@@ -51,7 +50,9 @@ def user_create(charm, event: ops.ActionEvent):
         return
 
     # Create the secret
-    if not (token := create_token(user, user, groups)):
+    groups: str = event.params.get("groups") or ""
+    group_list = [g.strip() for g in groups.split(",") if g]
+    if not (token := create_token(user, user, group_list)):
         event.fail("Failed to create secret for: {}".format(user))
         return
 

--- a/src/actions/users.py
+++ b/src/actions/users.py
@@ -51,7 +51,7 @@ def user_create(charm, event: ops.ActionEvent):
 
     # Create the secret
     groups: str = event.params.get("groups") or ""
-    group_list = [g.strip() for g in groups.split(",") if g]
+    group_list = [g.strip() for g in groups.split(",") if g.strip()]
     if not (token := create_token(user, user, group_list)):
         event.fail("Failed to create secret for: {}".format(user))
         return

--- a/src/auth_webhook.py
+++ b/src/auth_webhook.py
@@ -8,7 +8,7 @@ from base64 import b64decode, b64encode
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CalledProcessError, check_call, check_output
-from typing import Mapping
+from typing import List, Mapping
 
 import charms.contextual_status as status
 import yaml
@@ -118,7 +118,7 @@ def delete_token(secret_id: str):
     kubectl("delete", "secret", "-n", auth_secret_ns, secret_id, "--ignore-not-found=true")
 
 
-def create_token(uid, username, groups=[]):
+def create_token(uid: str, username: str, groups: List[str]):
     token = get_token(username)
     if token:
         return token

--- a/tests/integration/test_k8s_control_plane_charm.py
+++ b/tests/integration/test_k8s_control_plane_charm.py
@@ -67,3 +67,12 @@ async def test_getkubeconfig(ops_test: OpsTest):
     action = await cp.units[0].run_action("get-kubeconfig")
     result = await action.wait()
     assert result.results["kubeconfig"]
+
+
+async def test_user_create(ops_test: OpsTest):
+    cp = ops_test.model.applications["kubernetes-control-plane"]
+    actions = await cp.get_actions()
+    assert "user-create" in actions
+    action = await cp.units[0].run_action("user-create", name="testuser", groups="system:masters")
+    result = await action.wait()
+    assert result.results["kubeconfig"].startswith("juju scp")


### PR DESCRIPTION
### Overview
* Resolves [LP#2097158](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2097158) by performing a split by commas on groups input in the `user-create` action

Thanks to @xtrusia for his inspiration on #370 
