### PR TITLE
Do not mark succeeded or failed pods as unready

### DIFF
--- a/src/k8s_kube_system.py
+++ b/src/k8s_kube_system.py
@@ -64,11 +64,11 @@ def get_kube_system_pods_not_running(charm) -> Optional[List]:
         else:
             # Any other phase (Pending or Unknown) are not running if they aren't evicted
             not_running = pod_reason != "Evicted"
-        
+
         if not_running:
             pod_name, pod_ns = pod["metadata"]["namespace"], pod["metadata"]["name"]
             log.warning("Pod/%s/%s in phase=%s is not running because of reason=%s", pod_ns, pod_name, pod_phase, pod_reason)
-        
+
         return not_running
 
     not_running = [pod for pod in result["items"] if is_not_running(pod)]


### PR DESCRIPTION
 Currently the `get_kube_system_pods_not_running` function checks whether the valid (i.e. pods in `Running`, `Succeeded`, or `Failed` phase) pods are ready and if not, returns them as `unready` for the charm to wait on them. However, completed pods are [marked as not ready](https://github.com/kubernetes/kubernetes/issues/52738). Therefore, the charm will wait for completed pods to become ready, which will never happen. The charm will recover after the `Completed` or `Failed` job's TTL passes and Kubernetes collects them, but the process will become lengthy and unpreadictable since it depends on jobs' TTL. 

Current PR suggests a fix to only check the `Running` pods for readiness. 