### PR TITLE
Add charm config to ignore missing CNI, and block when CNI is missing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -186,6 +186,12 @@ options:
       Space separated list of pod names in the kube-system namespace to ignore
       when checking for running pods. Any non-Running Pod whose name is on
       this list, will be ignored during the check.
+  ignore-missing-cni:
+    type: boolean
+    default: false
+    description: |
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation.
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".
   image-registry:
     type: string
     default: "rocks.canonical.com:443/cdk"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime@main
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@main
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@main
@@ -6,18 +5,19 @@ charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/c
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@main
 charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@main
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
-charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@main
-ops.interface-kube-control==0.2.0
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@main#subdirectory=ops
 ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops
 ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops
 ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@main#subdirectory=ops
 aiohttp == 3.7.4
 cosl==0.0.47
+charms.reconciler == 0.0.0
+charms.contextual-status == 0.0.0
 jinja2 == 3.1.3
 loadbalancer_interface == 1.2.0
 ops == 2.12.0
+ops.interface-kube-control==0.2.0
 pydantic == 1.10.15
 tenacity == 8.2.3
 # kv and vault-kv

--- a/src/k8s_kube_system.py
+++ b/src/k8s_kube_system.py
@@ -67,7 +67,13 @@ def get_kube_system_pods_not_running(charm) -> Optional[List]:
 
         if not_running:
             pod_name, pod_ns = pod["metadata"]["namespace"], pod["metadata"]["name"]
-            log.warning("Pod/%s/%s in phase=%s is not running because of reason=%s", pod_ns, pod_name, pod_phase, pod_reason)
+            log.warning(
+                "Pod/%s/%s in phase=%s is not running because of reason=%s",
+                pod_ns,
+                pod_name,
+                pod_phase,
+                pod_reason,
+            )
 
         return not_running
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,9 +4,11 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import json
+import logging
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
+import charms.contextual_status as status
 import ops
 import ops.testing
 import pytest
@@ -51,6 +53,7 @@ def harness():
 @patch("charms.node_base.LabelMaker.active_labels")
 @patch("charms.node_base.LabelMaker.set_label")
 @patch("charms.node_base.LabelMaker.remove_label")
+@patch("pathlib.Path.exists", MagicMock(return_value=True))
 def test_active(
     remove_label,
     set_label,
@@ -257,3 +260,23 @@ def test_manage_ports(
 
     harness.charm.manage_ports(mock_close)
     mock_close.assert_called_once_with(*port_params)
+
+
+def test_ignore_missing_cni(harness, caplog):
+    """Verify that if CNI relation is missing, it can be ignored."""
+    harness.disable_hooks()
+    harness.begin()
+
+    # CNI relation is not added and not ignored, raise an error
+    harness.update_config({"ignore-missing-cni": False})
+    with pytest.raises(status.ReconcilerError):
+        harness.charm.configure_cni()
+
+    # CNI relation is not added yet ignored, silently ignore
+    with caplog.at_level(logging.INFO):
+        caplog.clear()
+        harness.update_config({"ignore-missing-cni": True})
+        harness.charm.configure_cni()
+        infos = [log[2] for log in caplog.record_tuples if log[1] == logging.INFO]
+        assert len(infos) == 1, "There should be only one info level log"
+        assert ["Ignoring missing CNI configuration as per user request."] == infos

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -262,7 +262,8 @@ def test_manage_ports(
     mock_close.assert_called_once_with(*port_params)
 
 
-def test_ignore_missing_cni(harness, caplog):
+@patch("charms.kubernetes_snaps.set_default_cni_conf_file")
+def test_ignore_missing_cni(set_default_cni_conf_file, harness, caplog):
     """Verify that if CNI relation is missing, it can be ignored."""
     harness.disable_hooks()
     harness.begin()
@@ -280,3 +281,4 @@ def test_ignore_missing_cni(harness, caplog):
         infos = [log[2] for log in caplog.record_tuples if log[1] == logging.INFO]
         assert len(infos) == 1, "There should be only one info level log"
         assert ["Ignoring missing CNI configuration as per user request."] == infos
+        set_default_cni_conf_file.assert_called_once_with(None)


### PR DESCRIPTION
Link to bug: [LP#2009525](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2009525)

Fix regression introduced in 1.29 by losing a feature that existed.
* add's back charm config `ignore-missing-cni`
* blocks if the cni is missing and not intentionally ignored

### Dependent PRs (?)
* https://github.com/charmed-kubernetes/charm-lib-reconciler/pull/5
* https://github.com/charmed-kubernetes/charm-lib-contextual-status/pull/4
* https://github.com/charmed-kubernetes/charm-kubernetes-worker/pull/184