### PR TITLE
 Prepare patch build for Manual CNI deployments

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -39,13 +39,13 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp
       - name: Upload charmcraft logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charmcraft-logs
           path: "/home/ubuntu/.local/state/charmcraft/log/*"

--- a/config.yaml
+++ b/config.yaml
@@ -186,6 +186,12 @@ options:
       Space separated list of pod names in the kube-system namespace to ignore
       when checking for running pods. Any non-Running Pod whose name is on
       this list, will be ignored during the check.
+  ignore-missing-cni:
+    type: boolean
+    default: false
+    description: |
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation.
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".
   image-registry:
     type: string
     default: "rocks.canonical.com:443/cdk"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@release_1.31
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@release_1.31
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@release_1.31
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@release_1.31
+charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@no-cni/release-1.31
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@release_1.31#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@release_1.31
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@release_1.31

--- a/src/actions/cis_benchmark.py
+++ b/src/actions/cis_benchmark.py
@@ -45,7 +45,7 @@ class Remedy:
         """Run the remedy command."""
         if self.type == "manual":
             log.info(
-                "Test %s: unable to auto-apply remedy.\n" "Manual steps:\n%s",
+                "Test %s: unable to auto-apply remedy.\nManual steps:\n%s",
                 test_num,
                 test_remediation,
             )
@@ -69,7 +69,7 @@ CONSERVATIVE = {
 ADMISSION_PLUGINS = {
     "enable-admission-plugins": (
         "PersistentVolumeLabel",
-        "PodSecurityPolicy," "AlwaysPullImages",
+        "PodSecurityPolicy,AlwaysPullImages",
         "NodeRestriction",
     )
 }
@@ -169,7 +169,7 @@ class CISBenchmark(ops.Object):
 
             # Setup the 'go' environment
             env = os.environ.copy()
-            go_bin = shutil.which("go", path=f'{env["PATH"]}:/snap/bin')
+            go_bin = shutil.which("go", path=f"{env['PATH']}:/snap/bin")
             if not go_bin:
                 try:
                     cmd = ["snap", "install", "go", "--channel=stable", "--classic"]
@@ -269,11 +269,7 @@ class CISBenchmark(ops.Object):
         self._restart_charm(event)
 
         event.set_results(
-            {
-                "summary": (
-                    "Reset is complete. Re-run with " '"apply=none" to generate a new report.'
-                )
-            }
+            {"summary": ('Reset is complete. Re-run with "apply=none" to generate a new report.')}
         )
 
     def craft_extra_args(self, service: str, args: dict):

--- a/src/charm.py
+++ b/src/charm.py
@@ -54,6 +54,12 @@ log = logging.getLogger(__name__)
 OBSERVABILITY_ROLE = "system:cos"
 
 
+class MissingCNIError(Exception):
+    """Exception raised when CNI is missing and not ignored."""
+
+    ERR = "Missing CNI relation or config"
+
+
 def charm_track() -> str:
     """Get the charm track based on the current charm branch.
 
@@ -281,12 +287,26 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         sandbox_image = kubernetes_snaps.get_sandbox_image(registry)
         self.container_runtime.set_sandbox_image(sandbox_image)
 
+    @status.on_error(ops.BlockedStatus(MissingCNIError.ERR), MissingCNIError)
     def configure_cni(self):
         status.add(ops.MaintenanceStatus("Configuring CNI"))
         self.cni.set_image_registry(self.model.config["image-registry"])
         self.cni.set_kubeconfig_hash_from_file(ROOT_KUBECONFIG)
         self.cni.set_service_cidr(self.model.config["service-cidr"])
-        kubernetes_snaps.set_default_cni_conf_file(self.cni.cni_conf_file)
+
+        ignore_missing_cni = self.model.config["ignore-missing-cni"]
+        conf_file = self.cni.cni_conf_file
+
+        if not conf_file and not ignore_missing_cni:
+            raise MissingCNIError()
+
+        if not conf_file and ignore_missing_cni:
+            log.info("Ignoring missing CNI configuration as per user request.")
+
+        # It's okay to set_default_cni_conf_file when conf_file == None
+        # because it will delete the existing default and not update
+        # to the new one
+        kubernetes_snaps.set_default_cni_conf_file(conf_file)
 
     def configure_controller_manager(self):
         status.add(ops.MaintenanceStatus("Configuring Controller Manager"))

--- a/src/k8s_kube_system.py
+++ b/src/k8s_kube_system.py
@@ -63,5 +63,4 @@ def get_kube_system_pods_not_running(charm) -> Optional[List]:
         return status["phase"] not in valid_phases and status.get("reason", "") != "Evicted"
 
     not_running = [pod for pod in result["items"] if is_invalid(pod) or not is_ready(pod)]
-
     return not_running

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -41,7 +41,7 @@ def test_upgrade_action_fails(upgrade_snaps: mock.Mock, harness):
     """Verify that the upgrade action runs the upgrade_snap method and reconciles."""
 
     def mock_upgrade(channel, event, control_plane):
-        assert channel == "latest/edge"
+        assert channel == harness.charm.config["channel"]
         assert control_plane is True
         status.add(ops.BlockedStatus("snap-upgrade-failed"))
         event.fail("snap upgrade failed")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,9 +4,11 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import json
+import logging
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
+import charms.contextual_status as status
 import ops
 import ops.testing
 import pytest
@@ -51,6 +53,7 @@ def harness():
 @patch("charms.node_base.LabelMaker.active_labels")
 @patch("charms.node_base.LabelMaker.set_label")
 @patch("charms.node_base.LabelMaker.remove_label")
+@patch("pathlib.Path.exists", MagicMock(return_value=True))
 def test_active(
     remove_label,
     set_label,
@@ -257,3 +260,25 @@ def test_manage_ports(
 
     harness.charm.manage_ports(mock_close)
     mock_close.assert_called_once_with(*port_params)
+
+
+@patch("charms.kubernetes_snaps.set_default_cni_conf_file")
+def test_ignore_missing_cni(set_default_cni_conf_file, harness, caplog):
+    """Verify that if CNI relation is missing, it can be ignored."""
+    harness.disable_hooks()
+    harness.begin()
+
+    # CNI relation is not added and not ignored, raise an error
+    harness.update_config({"ignore-missing-cni": False})
+    with pytest.raises(status.ReconcilerError):
+        harness.charm.configure_cni()
+
+    # CNI relation is not added yet ignored, silently ignore
+    with caplog.at_level(logging.INFO):
+        caplog.clear()
+        harness.update_config({"ignore-missing-cni": True})
+        harness.charm.configure_cni()
+        infos = [log[2] for log in caplog.record_tuples if log[1] == logging.INFO]
+        assert len(infos) == 1, "There should be only one info level log"
+        assert ["Ignoring missing CNI configuration as per user request."] == infos
+        set_default_cni_conf_file.assert_called_once_with(None)


### PR DESCRIPTION
### Overview 
Preparing a new channel for testing without a CNI deployed in 1.31 Charmed Kubernetes

### Details
* Apply `ignore-missing-cni` configuration
* inclusion of addresses from the `lo` interface when building the Server Certificate SANS
* Adjustments to engage CI appropriately