### PR TITLE
bug: Validate allow-privileged configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,15 +1,23 @@
 options:
   allow-privileged:
     type: string
-    default: "auto"
+    default: "false"
     description: |
       Allow kube-apiserver to run in privileged mode. Supported values are
-      "true", "false", and "auto". If "true", kube-apiserver will run in
-      privileged mode by default. If "false", kube-apiserver will never run in
-      privileged mode. If "auto", kube-apiserver will not run in privileged
-      mode by default, unless certain circumstances are discovered
-         * gpu hardware is detected on a worker node
-         * openstack-integrator successfully related
+      "true", "false", and "auto (deprecated)".
+
+      If "true", kube-apiserver will run in privileged mode.
+      If "false", kube-apiserver will never run in privileged mode.
+
+      Deprecated option:
+      If "auto", kube-apiserver will never run in privileged mode.
+      This mode was the previous default, so it's value is retained for backwards compatibility.
+
+      Prior to 1.29, kube-apiserver would run in privileged mode if the following conditions were met:
+      * gpu hardware is detected on a worker node
+      * openstack-integrator successfully related
+
+      Any other configuration will result in the charm blocked with an error message.
 
   api-extra-args:
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -1,21 +1,17 @@
 options:
   allow-privileged:
     type: string
-    default: "false"
+    default: "auto"
     description: |
-      Allow kube-apiserver to run in privileged mode. Supported values are
-      "true", "false", and "auto (deprecated)".
+      Allows kube-apiserver to accept privileged containers. Supported values
+      are "true", "false", and "auto".
 
-      If "true", kube-apiserver will run in privileged mode.
-      If "false", kube-apiserver will never run in privileged mode.
-
-      Deprecated option:
-      If "auto", kube-apiserver will never run in privileged mode.
-      This mode was the previous default, so it's value is retained for backwards compatibility.
-
-      Prior to 1.29, kube-apiserver would run in privileged mode if the following conditions were met:
-      * gpu hardware is detected on a worker node
-      * openstack-integrator successfully related
+      If "true",  kube-apiserver allows privileged containers
+      If "false", kube-apiserver never allows privileged containers
+      If "auto",  kube-apiserver allows privileged containers under the
+          following conditions:
+      * any privileged cni is related
+      * container-runtime states nvidia_enabled
 
       Any other configuration will result in the charm blocked with an error message.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -199,12 +199,38 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         return " ".join(f"{k}={v}" for k, v in args.items())
 
     @property
+    def _any_privileged_cni(self) -> bool:
+        """Returns boolean indicating relation to a CNI requiring privilege."""
+        cni_conf_file = self.cni.cni_conf_file
+        if not cni_conf_file:
+            return False
+        require_priv = {"calico", "kube-ovn", "cilium"}
+        cni_conf_files = {
+            rel.data[unit].get("cni-conf-file", "")
+            for rel in self.cni.relations
+            for unit in rel.units
+        }
+        return any(app in fname for fname in cni_conf_files for app in require_priv)
+
+    @property
+    def _gpu_enabled(self) -> bool:
+        """Returns boolean if any container_runtime has nvidia_enabled."""
+        return any(
+            rel.data[unit].get("nvidia_enabled", "") == "true"
+            for rel in self.container_runtime.relations
+            for unit in rel.units
+        )
+
+    @property
     def allows_privileged(self) -> bool:
         val = self.model.config["allow-privileged"].lower()
         if val not in ["true", "false", "auto"]:
             status.add(ops.BlockedStatus("Invalid config for allow-privileged"))
             return False
-        return val == "true"
+        if val == "auto":
+            return self._any_privileged_cni or self._gpu_enabled
+        else:
+            return val == "true"
 
     def configure_apiserver(self):
         status.add(ops.MaintenanceStatus("Configuring API Server"))

--- a/src/charm.py
+++ b/src/charm.py
@@ -198,7 +198,8 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         args = self.cis_benchmark.craft_extra_args(service_name, extra_args)
         return " ".join(f"{k}={v}" for k, v in args.items())
 
-    def allow_privileged(self) -> bool:
+    @property
+    def allows_privileged(self) -> bool:
         val = self.model.config["allow-privileged"].lower()
         if val not in ["true", "false", "auto"]:
             status.add(ops.BlockedStatus("Invalid config for allow-privileged"))
@@ -216,7 +217,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
             cluster_cidr=self.cni.cidr,
             etcd_connection_string=self.etcd.get_connection_string(),
             extra_args_config=self.service_extra_args("kube-apiserver", "api-extra-args"),
-            privileged=self.allow_privileged(),
+            privileged=self.allows_privileged,
             service_cidr=self.model.config["service-cidr"],
             external_cloud_provider=self.external_cloud_provider,
             authz_webhook_conf_file=auth_webhook.authz_webhook_conf,

--- a/src/cos_integration.py
+++ b/src/cos_integration.py
@@ -106,7 +106,10 @@ class COSIntegration:
                 metrics_path="/metrics",
                 scheme="https",
                 target="localhost:6443",
-                relabel_configs=[{"target_label": "job", "replacement": "apiserver"}, instance_relabel],
+                relabel_configs=[
+                    {"target_label": "job", "replacement": "apiserver"},
+                    instance_relabel,
+                ],
             ),
             JobConfig(
                 name="kube-proxy",
@@ -120,15 +123,21 @@ class COSIntegration:
                 metrics_path="/metrics",
                 scheme="https",
                 target="localhost:10259",
-                relabel_configs=[{"target_label": "job", "replacement": "kube-scheduler"}, instance_relabel],
+                relabel_configs=[
+                    {"target_label": "job", "replacement": "kube-scheduler"},
+                    instance_relabel,
+                ],
             ),
             JobConfig(
                 name="kube-controller-manager",
                 metrics_path="/metrics",
                 scheme="https",
                 target="localhost:10257",
-                relabel_configs=[{"target_label": "job", "replacement": "kube-controller-manager"}, instance_relabel],
-            )
+                relabel_configs=[
+                    {"target_label": "job", "replacement": "kube-controller-manager"},
+                    instance_relabel,
+                ],
+            ),
         ]
         kubelet_metrics_paths = [
             "/metrics",

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -4,8 +4,6 @@ applications:
     charm: {{charm}}
     channel: null
     series: {{series}}
-    options:
-      allow-privileged: true
     resources:
       cni-plugins: {{resource_path}}/cni-plugins-{{arch}}.tar.gz
   grafana-agent:

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -4,6 +4,8 @@ applications:
     charm: {{charm}}
     channel: null
     series: {{series}}
+    options:
+      allow-privileged: true
     resources:
       cni-plugins: {{resource_path}}/cni-plugins-{{arch}}.tar.gz
   grafana-agent:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -161,7 +161,7 @@ def test_active(
         cluster_cidr="192.168.0.0/16",
         etcd_connection_string="https://10.0.0.11:2379",
         extra_args_config="",
-        privileged="auto",
+        privileged=False,
         service_cidr="10.152.183.0/24",
         external_cloud_provider=harness.charm.external_cloud_provider,
         authz_webhook_conf_file=Path("/root/cdk/auth-webhook/authz-webhook-conf.yaml"),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -161,7 +161,7 @@ def test_active(
         cluster_cidr="192.168.0.0/16",
         etcd_connection_string="https://10.0.0.11:2379",
         extra_args_config="",
-        privileged=False,
+        privileged=True,
         service_cidr="10.152.183.0/24",
         external_cloud_provider=harness.charm.external_cloud_provider,
         authz_webhook_conf_file=Path("/root/cdk/auth-webhook/authz-webhook-conf.yaml"),


### PR DESCRIPTION
[LP#2058246](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2058246)
[LP#2106755](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2106755)


### Overview
Validate charm configuration of `allow-privilged` to be either `false`, `true`, or `auto` and nothing else


### Details
* changing the default from `auto` to `false`  -- lets just go with secure by default shall we?
* allow for any-case of `true`/`false`
* stricter requirements on the value to be a string of `false`, `true`, or `auto`