### PR TITLE
fix setuptools requirements for jammy and noble

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -533,9 +533,13 @@ bases:
       architectures: ["s390x"]
 parts:
   charm:
-    build-packages: [git]
+    plugin: charm
+    build-packages:
+    - git
+    charm-python-packages:
+    - setuptools==79.0.0
     prime:
-      - templates/**
+    - templates/**
   branch:
     # save the branch name into the charm
     after: [charm]


### PR DESCRIPTION
### Overview
charmcraft 2.x installs `setuptools-59.6.0` by default, which doesn't work with noble

### Details
* force to using [`setuptools==79.0.0`](https://pypi.org/project/setuptools/79.0.0/), which claims support for `python >= 3.9`