### PR TITLE
fix: support dual stack kubelet node ip addresses

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -66,9 +66,7 @@ class MissingCNIError(Exception):
 
 
 class DualStackNodeIPError(Exception):
-    """Exception raised when there is an issue obtaining node IP(s) for kubelet
-    in a dual stack configuration.
-    """
+    """Exception raised when there is an issue obtaining node IP(s) for kubelet in a dual stack configuration."""
 
 
 def charm_track() -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -799,6 +799,7 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
 
     def _check_core_services(self, services):
         for service in services:
+            log.info(f"checking the status of {service}")
             has_failed, reason = self._service_has_failed(service)
             if has_failed:
                 status.add(ops.BlockedStatus(f"{service} has failed: {reason}"))


### PR DESCRIPTION
To addresss a similar issue as https://github.com/canonical/k8s-snap/issues/1448, this PR suggest changes to update the `--node-ip` flag of kubelet on control plane charm to include both ipv4 and ipv6 addresses, if present, which became a Cilium requirement with 1.17. It also checks that the IPs are not unspecified in case of a dual stack environment as per kubelet's requirement. 