### PR TITLE
chore: switch to base from series

### DIFF
--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -3,11 +3,11 @@ applications:
   kubernetes-control-plane:
     charm: {{charm}}
     channel: null
-    series: {{series}}
+    base: {{base}}
     resources:
       cni-plugins: {{resource_path}}/cni-plugins-{{arch}}.tar.gz
   grafana-agent:
     charm: grafana-agent
-    series: {{series}}
+    base: {{base}}
 relations:
 - [ kubernetes-control-plane:cos-agent, grafana-agent:cos-agent ]

--- a/tests/integration/test_k8s_control_plane_charm.py
+++ b/tests/integration/test_k8s_control_plane_charm.py
@@ -10,8 +10,8 @@ from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
 
-
-SERIES = "jammy"
+# TODO: update the pytest-operator to support base
+BASE = "jammy"
 
 
 @pytest.mark.abort_on_fail
@@ -33,10 +33,10 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     log.info("Building bundle")
     bundle, *overlays = await ops_test.async_render_bundles(
-        ops_test.Bundle("kubernetes-core", channel="edge", series=SERIES),
+        ops_test.Bundle("kubernetes-core", channel="edge", base=BASE),
         Path("tests/data/charm.yaml"),
         arch="amd64",
-        series=SERIES,
+        base=BASE,
         charm=charm.resolve(),
         resource_path=resource_path,
     )


### PR DESCRIPTION
As implemented in https://github.com/juju/juju/pull/17169, the `series` option is deprecated and planned for removal in version 4 in favor of the `base`. This PR suggests a change to use `base` instead of `series` in the overlay file used in integration tests.