### PR TITLE
chore: switch integration tests to noble

### DIFF
--- a/tests/integration/test_k8s_control_plane_charm.py
+++ b/tests/integration/test_k8s_control_plane_charm.py
@@ -11,7 +11,7 @@ from pytest_operator.plugin import OpsTest
 log = logging.getLogger(__name__)
 
 
-SERIES = "jammy"
+SERIES = "noble"
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
Switches the integration test `series` from `jammy` to `noble`