### PR TITLE
[release_1.32] fix: `ignore-missing-cni`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -186,6 +186,12 @@ options:
       Space separated list of pod names in the kube-system namespace to ignore
       when checking for running pods. Any non-Running Pod whose name is on
       this list, will be ignored during the check.
+  ignore-missing-cni:
+    type: boolean
+    default: false
+    description: |
+      If ignore-missing-cni is set to true, the charm will not enter a blocked state if a CNI has not been configured/provided via relation.
+      If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".
   image-registry:
     type: string
     default: "rocks.canonical.com:443/cdk"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
-charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@release_1.32
 charm-lib-interface-container-runtime @ git+https://github.com/charmed-kubernetes/charm-lib-interface-container-runtime@release_1.32
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@release_1.32
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@release_1.32
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@release_1.32
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@release_1.32
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@release_1.32
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@release_1.32#subdirectory=ops
-charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@release_1.32
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@release_1.32
 ops.interface_kube_control == 0.2.0
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@release_1.32#subdirectory=ops
@@ -15,9 +12,13 @@ ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-inte
 ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@release_1.32#subdirectory=ops
 aiohttp == 3.7.4
 cosl==0.0.47
+charms.reconciler == 0.0.0
+charms.contextual-status == 0.0.0
+charms.kubernetes-snaps == 0.0.0
 jinja2 == 3.1.3
 loadbalancer_interface == 1.2.1
 ops == 2.12.0
+ops.interface-kube-control==0.2.0
 pydantic == 1.10.15
 tenacity == 8.2.3
 # kv and vault-kv

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,6 +59,12 @@ class RefreshCosAgent(ops.EventBase):
     """Event to trigger a refresh of the COS agent."""
 
 
+class MissingCNIError(Exception):
+    """Exception raised when CNI is missing and not ignored."""
+
+    ERR = "Missing CNI relation or config"
+
+
 def charm_track() -> str:
     """Get the charm track based on the current charm branch.
 
@@ -289,12 +295,26 @@ class KubernetesControlPlaneCharm(ops.CharmBase):
         sandbox_image = kubernetes_snaps.get_sandbox_image(registry)
         self.container_runtime.set_sandbox_image(sandbox_image)
 
+    @status.on_error(ops.BlockedStatus(MissingCNIError.ERR), MissingCNIError)
     def configure_cni(self):
         status.add(ops.MaintenanceStatus("Configuring CNI"))
         self.cni.set_image_registry(self.model.config["image-registry"])
         self.cni.set_kubeconfig_hash_from_file(ROOT_KUBECONFIG)
         self.cni.set_service_cidr(self.model.config["service-cidr"])
-        kubernetes_snaps.set_default_cni_conf_file(self.cni.cni_conf_file)
+
+        ignore_missing_cni = self.model.config["ignore-missing-cni"]
+        conf_file = self.cni.cni_conf_file
+
+        if not conf_file and not ignore_missing_cni:
+            raise MissingCNIError()
+
+        if not conf_file and ignore_missing_cni:
+            log.info("Ignoring missing CNI configuration as per user request.")
+
+        # It's okay to set_default_cni_conf_file when conf_file == None
+        # because it will delete the existing default and not update
+        # to the new one
+        kubernetes_snaps.set_default_cni_conf_file(conf_file)
 
     def configure_controller_manager(self):
         status.add(ops.MaintenanceStatus("Configuring Controller Manager"))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,9 +4,11 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import json
+import logging
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
+import charms.contextual_status as status
 import ops
 import ops.testing
 import pytest
@@ -51,6 +53,7 @@ def harness():
 @patch("charms.node_base.LabelMaker.active_labels")
 @patch("charms.node_base.LabelMaker.set_label")
 @patch("charms.node_base.LabelMaker.remove_label")
+@patch("pathlib.Path.exists", MagicMock(return_value=True))
 def test_active(
     remove_label,
     set_label,
@@ -257,3 +260,25 @@ def test_manage_ports(
 
     harness.charm.manage_ports(mock_close)
     mock_close.assert_called_once_with(*port_params)
+
+
+@patch("charms.kubernetes_snaps.set_default_cni_conf_file")
+def test_ignore_missing_cni(set_default_cni_conf_file, harness, caplog):
+    """Verify that if CNI relation is missing, it can be ignored."""
+    harness.disable_hooks()
+    harness.begin()
+
+    # CNI relation is not added and not ignored, raise an error
+    harness.update_config({"ignore-missing-cni": False})
+    with pytest.raises(status.ReconcilerError):
+        harness.charm.configure_cni()
+
+    # CNI relation is not added yet ignored, silently ignore
+    with caplog.at_level(logging.INFO):
+        caplog.clear()
+        harness.update_config({"ignore-missing-cni": True})
+        harness.charm.configure_cni()
+        infos = [log[2] for log in caplog.record_tuples if log[1] == logging.INFO]
+        assert len(infos) == 1, "There should be only one info level log"
+        assert ["Ignoring missing CNI configuration as per user request."] == infos
+        set_default_cni_conf_file.assert_called_once_with(None)


### PR DESCRIPTION
## Overview
Port the `ignore-missing-cni` to release_1.32.