### PR TITLE
[release_1.33] chore: use `charms.kubernetes-snaps` package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@release_1.33
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@release_1.33
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@release_1.33
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@release_1.33
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@release_1.33#subdirectory=ops
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@release_1.33
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@release_1.33#subdirectory=ops
@@ -14,6 +13,7 @@ aiohttp == 3.7.4
 cosl==0.0.47
 charms.reconciler == 0.0.0
 charms.contextual-status == 0.0.0
+charms.kubernetes-snaps == 0.0.0
 jinja2 == 3.1.3
 loadbalancer_interface == 1.2.1
 ops == 2.12.0


### PR DESCRIPTION
## Overview
Change `charms.kubernetes-snaps` to a Python package.