### PR TITLE
[release_1.34] chore: use `charms.kubernetes-snaps` package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kub
 charm-lib-interface-kube-dns @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kube-dns@release_1.34
 charm-lib-interface-kubernetes-cni @ git+https://github.com/charmed-kubernetes/charm-lib-interface-kubernetes-cni@release_1.34
 charm-lib-interface-tokens @ git+https://github.com/charmed-kubernetes/charm-lib-interface-tokens@release_1.34
-charm-lib-kubernetes-snaps @ git+https://github.com/charmed-kubernetes/charm-lib-kubernetes-snaps@release_1.34
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@3d7b34bd10aa5ef8dfca4f671a6e4757ec6c153a#subdirectory=ops
 interface_hacluster @ git+https://github.com/charmed-kubernetes/charm-interface-hacluster@release_1.34
 ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates@release_1.34#subdirectory=ops
@@ -14,6 +13,7 @@ aiohttp == 3.7.4
 cosl==0.0.47
 charms.reconciler == 0.0.0
 charms.contextual-status == 0.0.0
+charms.kubernetes-snaps == 0.0.0
 jinja2 == 3.1.3
 loadbalancer_interface == 1.2.1
 ops == 2.12.0

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -42,6 +42,7 @@ def harness():
 @patch("charms.kubernetes_snaps.get_public_address")
 @patch("charms.kubernetes_snaps.is_snap_installed")
 @patch("charms.kubernetes_snaps.install_snap")
+@patch("charms.kubernetes_snaps.install")
 @patch("charms.kubernetes_snaps.set_default_cni_conf_file")
 @patch("charms.kubernetes_snaps.write_certificates")
 @patch("charms.kubernetes_snaps.write_etcd_client_credentials")
@@ -67,6 +68,7 @@ def test_active(
     write_certificates,
     set_default_cni_conf_file,
     install_snap,
+    install,
     is_snap_installed,
     get_public_address,
     update_kubeconfig,
@@ -217,6 +219,7 @@ def test_active(
     configure_services_restart_always.assert_called_once_with(control_plane=True)
     update_kubeconfig.assert_called()
     install_snap.assert_called()
+    install.assert_called()
     install_cni_binaries.assert_called()
     set_default_cni_conf_file.assert_called_once_with("10-calico.conflist")
     write_certificates.assert_called_once_with(


### PR DESCRIPTION
## Overview
Change `charms.kubernetes-snaps` to a Python package.