### PR TITLE
Update image-registry default to ghcr.io/canonical/cdk

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -221,7 +221,7 @@ config:
         If ignore-missing-cni is set to false, and a CNI has not been configured/provided via relation, then the charm will enter a blocked state with the message: "Missing CNI relation or config".
     image-registry:
       type: string
-      default: "rocks.canonical.com:443/cdk"
+      default: "ghcr.io/canonical/cdk"
       description: |
         Container image registry to use for CDK. This includes addons like the Kubernetes dashboard,
         metrics server, ingress, and dns along with non-addon images including the pause

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -201,7 +201,7 @@ def test_active(
         external_cloud_provider=harness.charm.external_cloud_provider,
         kubeconfig="/root/cdk/kubeconfig",
         node_ip="10.0.0.10",
-        registry="rocks.canonical.com:443/cdk",
+        registry="ghcr.io/canonical/cdk",
         taints=["node-role.kubernetes.io/control-plane:NoSchedule"],
     )
     configure_kube_proxy.assert_called_once_with(


### PR DESCRIPTION
`rocks.canonical.com` is being retired. This PR updates the image registry
references from the legacy registry to the new GitHub Container Registry.

**Changes:**
- `rocks.canonical.com:443/cdk` → `ghcr.io/canonical/cdk`
- `rocks.canonical.com/cdk` → `ghcr.io/canonical/cdk`
